### PR TITLE
Add doc-sync agents and external baseline review

### DIFF
--- a/.claude/agents/architecture-sync.md
+++ b/.claude/agents/architecture-sync.md
@@ -1,0 +1,10 @@
+---
+name: architecture-sync
+model: sonnet
+---
+
+Keep architecture docs factually aligned with the codebase.
+
+- Routine write scope: `docs/architecture/*.md`, `docs/analysis/*.md`
+- Critical decisions go to `docs/analysis/PENDING_REVIEW.md` instead of direct doc edits
+- Flag training strategy, base model choice, evaluation contract, dataset composition, solver architecture, and `src/` contradictions

--- a/.claude/agents/doc-orchestrator.md
+++ b/.claude/agents/doc-orchestrator.md
@@ -6,7 +6,7 @@ model: haiku
 Read `git diff --name-only`, classify touched files, and dispatch specialist agents in parallel.
 
 - No writes.
-- ROUTING: `AGENTS.md`, `CLAUDE.md`, `docs/README.md`, new top-level dirs
+- ROUTING: `AGENTS.md`, `docs/README.md`, new top-level dirs; `CLAUDE.md` if present
 - EXECUTION: `notebooks/`, `docs/execution/`, `src/`, `configs/`
 - LEARN: any substantive commit; check relevance first
 - ARCHITECTURE: `docs/architecture/`, `docs/analysis/`, `docs/planning/`, system-level `src/`

--- a/.claude/agents/doc-orchestrator.md
+++ b/.claude/agents/doc-orchestrator.md
@@ -1,0 +1,12 @@
+---
+name: doc-orchestrator
+model: haiku
+---
+
+Read `git diff --name-only`, classify touched files, and dispatch specialist agents in parallel.
+
+- No writes.
+- ROUTING: `AGENTS.md`, `CLAUDE.md`, `docs/README.md`, new top-level dirs
+- EXECUTION: `notebooks/`, `docs/execution/`, `src/`, `configs/`
+- LEARN: any substantive commit; check relevance first
+- ARCHITECTURE: `docs/architecture/`, `docs/analysis/`, `docs/planning/`, system-level `src/`

--- a/.claude/agents/execution-sync.md
+++ b/.claude/agents/execution-sync.md
@@ -1,0 +1,11 @@
+---
+name: execution-sync
+model: haiku
+---
+
+Keep execution docs aligned with notebook delivery.
+
+- Write scope: `docs/execution/NOTEBOOKS.md`, `docs/execution/SPRINTS.md`
+- Promote `scaffolded -> active` when a substantive notebook body lands
+- Promote `active -> validated` only from explicit test-pass evidence
+- Do not change issue ownership, dependency order, or wave structure

--- a/.claude/agents/learn-sync.md
+++ b/.claude/agents/learn-sync.md
@@ -1,0 +1,11 @@
+---
+name: learn-sync
+model: sonnet
+---
+
+Keep learner-facing docs current and beginner-friendly.
+
+- Write scope: `docs/learn/project/*.md`, `docs/learn/foundations/*.md`, `docs/learn/sources/citation-ledger.md`
+- May create new foundations pages from `docs/learn/_templates/page_template.md`
+- Do not collapse planned into implemented or invent results
+- Cite repo sources first

--- a/.claude/agents/routing-sync.md
+++ b/.claude/agents/routing-sync.md
@@ -1,0 +1,10 @@
+---
+name: routing-sync
+model: haiku
+---
+
+Keep repo routing docs aligned with the current tree.
+
+- Write scope: `AGENTS.md`, `CLAUDE.md`, `docs/README.md`
+- Update canonical pointers, navigation tables, and Last Updated metadata
+- Navigation only; do not change substantive project content

--- a/.claude/commands/doc-sync.md
+++ b/.claude/commands/doc-sync.md
@@ -1,0 +1,9 @@
+---
+name: doc-sync
+---
+
+Run the doc orchestrator over a commit range.
+
+- `WORKTREE` pre-commit sync mode: inspect the current worktree diff and sync docs before commit
+- Commit-range mode: `/doc-sync [range]` with optional `<range>`; default `HEAD~1..HEAD`
+- Dispatch the same orchestrator logic used by the post-commit hook

--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,6 @@ Thumbs.db
 
 # Local assistant/agent artifacts
 .codex
-.claude
+.claude/*.log
 claude-progress.txt
 init.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,20 @@
+# CLAUDE.md (Router)
+
+Route your task to the right docs. Keep context minimal — open only what your task needs.
+
+| Task | Go to |
+|------|-------|
+| Competition rules, dataset, scoring | `docs/architecture/COMPETITION.md` |
+| System / model design | `docs/architecture/ARCHITECTURE.md` |
+| Execution plan (source of truth) | `docs/planning/plan_v0.2.md` |
+| Sprint / issue tracking | `docs/execution/SPRINTS.md` |
+| Notebook registry & status | `docs/execution/NOTEBOOKS.md` |
+| Current repo state | `docs/learn/project/implemented-today.md` |
+| Analysis & adversarial review | `docs/analysis/` |
+| All docs index | `docs/README.md` |
+
+## Working rules
+
+- Reusable code → `src/`; keep notebooks thin.
+- Large artifacts (`data/`, `adapters/`, `experiments/`) stay out of git.
+- Every notebook must have a row in `docs/execution/NOTEBOOKS.md`.

--- a/TODO.md
+++ b/TODO.md
@@ -21,8 +21,8 @@ then keep issue comments and repo docs updated as artifacts become real.
   starting.
 - If a task changes a shared contract, it needs human review and, when noted,
   architecture review.
-- Do not run real SFT/QLoRA training until `#14` freezes the base model,
-  scoring contract, LoRA constraints, and submission rules.
+- Do not run real SFT/QLoRA training unless the run conforms to the verified
+  `#14` base model, scoring contract, LoRA constraints, and submission rules.
 - Do not promote prompt-sweep results until the output-parser contract is
   resolved and comparisons use compatible scoring.
 - Do not promote or submit adapters unless the golden gate from `#18` and the
@@ -95,9 +95,9 @@ Do not begin the dependent task until the upstream owner confirms:
 | `#11` | Open | Epic | `#25` SFT runbook/training |
 | `#12` | Open | Epic | `#13`, `#15` runbook/review harness |
 | `#13` | Closed | Execution | Notebook template + citation rubric |
-| `#14` | Closed | Execution | Constraints notebook, still externally gated |
+| `#14` | Closed | Execution | Verified constraints contract |
 | `#15` | Closed | Execution | Agent/human review harness |
-| `#16` | Closed | Execution | External baseline deltas, still `#14` gated |
+| `#16` | Closed | Execution | External baseline deltas; must conform to `#14` |
 | `#17` | Closed | Execution | Schema/code foundation |
 | `#18` | Closed | Execution | Split/golden code, real artifacts missing |
 | `#19` | Closed | Execution | Eval code, real baseline missing |
@@ -163,7 +163,7 @@ Out of scope / unable to confirm (noted in COMPETITION.md, not blocking):
 General chat warning:
 
 - Before any training, scoring promotion, or packaging promotion, confirm with
-  the PM that `#14` facts above are still current.
+  the PM that the verified `#14` contract above is still the working contract.
 - The 4-module target set from the demo is the reference; do not expand to
   konbu17's 9-module set without PM sign-off.
 
@@ -171,22 +171,24 @@ General chat warning:
 
 Owner lane: research / baseline comparison
 
-- [ ] Restore or re-fetch `data/external/konbu17/**` if repo-local evidence is
-  needed; current local `data/` has only placeholders.
-- [ ] Pull or manually capture konbu17 notebook facts:
+- [x] Create `docs/analysis/EXTERNAL_BASELINE_REVIEW.md` for the bounded
+  Tong (`tonghuikang`) + konbu17 review.
+- [x] Capture konbu17 notebook facts from existing repo-local evidence:
   base model, load recipe, LoRA config, target modules, masking behavior,
   dataset, eval protocol, packaging.
-- [ ] Review Tong Hui Kang public pipeline for masking, augmentation, weighting,
-  solver/teacher patterns, and packaging ideas.
-- [ ] Produce an Adopt / Reject / Gate matrix.
-- [ ] Link each Adopt/Gate decision to downstream issues:
+- [x] Review Tong (`tonghuikang`) public pipeline for masking, augmentation,
+  weighting, solver/teacher patterns, and packaging ideas.
+- [x] Produce an Adopt / Reject / Gate matrix.
+- [x] Link each Adopt/Gate decision to downstream issues:
   `#19`, `#20`, `#21`, `#23`, `#24`, `#25`.
-- [ ] Identify any baseline assumptions that conflict with exact-match scoring
+- [x] Identify any baseline assumptions that conflict with exact-match scoring
   or rank `<=32`.
 
 Blocked by:
 
-- `#14` for final base-model and output-format decisions.
+- None for the bounded Tong + konbu17 review. Future reproduction work remains
+  blocked by source availability, license/provenance capture, and PM signoff for
+  any baseline choice that deviates from the verified `#14` contract.
 
 General chat warning:
 
@@ -212,7 +214,7 @@ Owner lane: data
 
 Blocked by:
 
-- `#14` if Kaggle data/rules access remains blocked.
+- Kaggle data/rules access if the official dataset cannot be downloaded.
 
 General chat warning:
 
@@ -235,7 +237,8 @@ Owner lane: evaluation
 Blocked by:
 
 - `#17` canonical dataset rows.
-- `#14` scoring contract if selection depends on answer normalization.
+- Verified `#14` scoring contract must be applied if selection depends on
+  answer normalization.
 
 General chat warning:
 
@@ -260,7 +263,6 @@ Owner lane: evaluation
 
 Blocked by:
 
-- `#14` scoring contract.
 - `#17` canonical rows.
 - `#18` real eval artifacts.
 
@@ -286,7 +288,6 @@ Owner lane: packaging / release
 
 Blocked by:
 
-- `#14` final packaging rules.
 - `#19` eval provenance inputs.
 - `#25` real adapter output for final package.
 
@@ -314,7 +315,6 @@ Blocked by:
 
 - `#18` validation/golden files.
 - `#19` baseline run.
-- `#14` if output format is still unknown.
 - Pending parser-contract review.
 
 General chat warning:
@@ -416,7 +416,8 @@ Blocked by:
 
 - `#22` failure slices.
 - `#23` solver/teacher framework.
-- `#14` scoring/output format if completions include reasoning or boxed answers.
+- Verified `#14` scoring/output format must be applied if completions include
+  reasoning or boxed answers.
 
 General chat warning:
 
@@ -427,8 +428,8 @@ General chat warning:
 
 Owner lane: training
 
-- [ ] Remove or revise any `r=64` plan/config assumptions; default to rank
-  `<=32` unless Kaggle rules prove otherwise.
+- [x] Remove or revise stale `r=64` plan/config assumptions in coordination
+  docs; default to rank `<=32` per the verified `#14` contract.
 - [ ] Implement expected HPC scripts from the runbook:
   - `scripts/hpc/preflight.sh`
   - `scripts/hpc/tokenize_dataset.py`
@@ -438,8 +439,8 @@ Owner lane: training
   - `scripts/hpc/regression_gate.py`
   - `scripts/hpc/package_adapter.py`
   - `scripts/hpc/resume_from_latest.py`
-- [ ] Add training configs only after `#14` freezes base model and adapter
-  constraints.
+- [ ] Add training configs only when they use the verified `#14` base model and
+  adapter constraints.
 - [ ] Implement masking tests so prompt/user tokens are not trained unless
   explicitly intended.
 - [ ] Run a tiny SFT smoke job before any production run.
@@ -449,15 +450,14 @@ Owner lane: training
 
 Blocked by:
 
-- `#14` base model, LoRA constraints, scoring contract.
 - `#19` eval/golden gate.
 - `#23` solver framework if training data uses solver outputs.
 - `#24` synthetic data recipe for generated data.
 
 General chat warning:
 
-- Before submitting any GPU job, ask PM whether `#14` is frozen and ask
-  evaluation owner whether golden/validation gates are ready.
+- Before submitting any GPU job, ask PM whether the run uses the current `#14`
+  contract and ask evaluation owner whether golden/validation gates are ready.
 
 ### `#12` / `#13` / `#15` - Runbook, Templates, Review Harness
 
@@ -468,7 +468,7 @@ Owner lane: PM / process
 - [ ] Keep `docs/execution/SPRINTS.md`,
   `docs/execution/ISSUE_REVIEW_HARNESS.md`, and
   `docs/execution/NOTEBOOKS.md` synchronized.
-- [ ] Decide whether `NOTEBOOKS.md` is the canonical status source.
+- [x] Treat `docs/execution/NOTEBOOKS.md` as the canonical status source.
 - [ ] Update stale notebook plan statuses or explicitly mark them as historical
   plans.
 - [ ] Document reproducible submission flow after first valid adapter.
@@ -487,15 +487,16 @@ General chat warning:
 - [ ] Reconcile issue parent/dependency metadata against
   `docs/execution/SPRINTS.md`.
 - [ ] Break the `#18` / `#19` dependency cycle.
-- [ ] Decide whether `#16` formally depends on `#14` or only gates final
-  recommendations on `#14`.
+- [x] Resolve `#16` / `#14` dependency: the bounded baseline review is not
+  blocked by `#14`, but every recommendation must conform to the verified `#14`
+  contract.
 - [ ] Decide whether `#17` formally depends on `#15`.
 - [ ] Decide whether `#20` should list `#25` as a real dependency for final
   packaging, while keeping dummy packaging independent.
 - [ ] Align `#20` zip contract across all docs.
 - [ ] Align golden threshold policy: strict `20/20` vs any tolerated miss.
-- [ ] Propagate one eval-format policy after `#14` resolves exact-match vs
-  boxed output.
+- [x] Propagate the verified `#14` eval-format policy: boxed extraction with
+  exact match or `1e-3` numeric tolerance.
 - [ ] Add a producer issue for curated training data if `#22`/`#24`/`#25`
   require `data/processed/training_curated.jsonl`.
 - [ ] Align `#22` output paths with `#24` input paths.
@@ -529,13 +530,15 @@ Use new child issues instead of expanding epics directly.
   - Blocked by: `#23`, `#24`
 - [ ] `#31`: SFT masking smoke-run implementation.
   - Parent: `#11`
-  - Blocked by: `#14`, `#19`
+  - Blocked by: `#19`; must conform to the verified `#14` contract.
 - [ ] `#32`: Accepted dummy or first-adapter Kaggle submission evidence.
   - Parent: `#5`, `#12`
-  - Blocked by: `#14`, `#20`
-- [ ] `#33`: External baseline reproduction pass for konbu17/Tong-style ideas.
+  - Blocked by: `#20`; must conform to the verified `#14` contract.
+- [ ] `#33`: External baseline reproduction pass for konbu17 and Tong
+  (`tonghuikang`) ideas.
   - Parent: `#2`
-  - Blocked by: baseline source availability and `#14`
+  - Blocked by: baseline source availability, license/provenance capture, and
+    PM signoff for deviations from the verified `#14` contract.
 - [ ] `#34`: Optional RL/GRPO planning.
   - Parent: future training/research epic
   - Blocked by: strong SFT baseline and stable reward/eval contract.
@@ -550,7 +553,7 @@ Primary issues:
 
 Immediate tasks:
 
-- [ ] Freeze Kaggle constraints.
+- [x] Freeze Kaggle constraints in `docs/architecture/COMPETITION.md`.
 - [ ] Fix or assign process/test failure.
 - [ ] Resolve status/dependency drift.
 - [ ] Own general-chat dependency checks and review gates.
@@ -607,7 +610,7 @@ Primary issues:
 Immediate tasks:
 
 - [ ] Keep packaging tests green.
-- [ ] Implement training preflight only after constraints freeze.
+- [ ] Implement training preflight against the verified `#14` constraints.
 - [ ] Prepare synthetic-data recipe after solver/failure slices exist.
 - [ ] Run tiny SFT smoke job before production training.
 

--- a/docs/analysis/EXTERNAL_BASELINE_REVIEW.md
+++ b/docs/analysis/EXTERNAL_BASELINE_REVIEW.md
@@ -1,0 +1,75 @@
+# External Baseline Review
+
+**Date:** 2026-04-29  
+**Scope:** TODO.md `#2` / `#16` bounded review of Tong Hui Kang's public
+`tonghuikang/nemotron` repository and konbu17's public Kaggle notebook.  
+**Official contract source:** `#14`, captured in
+`docs/architecture/COMPETITION.md`. External baselines may inform implementation
+choices but do not override the official Kaggle/NVIDIA contract.
+
+## Source Identity
+
+| Source | Identity | Review status |
+|---|---|---|
+| Tong Hui Kang (`tonghuikang/nemotron`) | Public Progress Prize reference repository, not an organizer source | Reviewed from public GitHub at `82bd1880aa8a8986ad572ccd17ae35b2b5c7da85` |
+| konbu17 Kaggle notebook | Public competitor/reference notebook, not an organizer source | Reviewed from repo-local notebook evidence and public notebook URL; live Kaggle cells were not extractable in this environment |
+| Kaggle/NVIDIA `#14` source | Official competition/demo contract source | Frozen defaults already captured in `docs/architecture/COMPETITION.md` |
+
+## Official Defaults From `#14`
+
+Use these as defaults whenever external baselines differ:
+
+- Base model path: `metric/nemotron-3-nano-30b-a3b-bf16/transformers/default`.
+- Load recipe: `trust_remote_code=True`, `torch.bfloat16`,
+  `device_map="auto"`.
+- Scoring: final answer inside `\boxed{}`; exact string match or relative
+  numeric tolerance `1e-3`.
+- LoRA rank: `r <= 32`.
+- Demo target modules: `in_proj`, `out_proj`, `up_proj`, `down_proj`.
+- Submission zip root: `adapter_config.json` and
+  `adapter_model.safetensors`.
+
+## Baseline Facts
+
+| Dimension | Tong Hui Kang public repo | konbu17 notebook evidence |
+|---|---|---|
+| Base model | `nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16` in `train_sft.py` | KaggleHub `metric/nemotron-3-nano-30b-a3b-bf16/transformers/default` in notebook evidence |
+| Load recipe | Tokenizer uses `AutoTokenizer.from_pretrained(..., trust_remote_code=True)`; training client receives `base_model=cfg.model_name` | `trust_remote_code=True`, bf16, `attn_implementation="eager"`, pad-token fallback in local notebook evidence |
+| LoRA rank/config | `lora_rank=32`; Tinker client flags `train_mlp=True`, `train_attn=True`, `train_unembed=True`; no explicit PEFT target-module list found | `r=32`, `lora_alpha=32`, `lora_dropout=0.0`, `bias="none"`, `task_type=CAUSAL_LM` |
+| Target modules | Coarse Tinker flags only; no explicit module list found | 9-module set in prior local notebook evidence: `q_proj`, `k_proj`, `v_proj`, `o_proj`, `in_proj`, `out_proj`, `up_proj`, `down_proj`, `lm_head` |
+| Masking | Explicit token mask: prompt/user tokens masked, completion/reasoning tokens unmasked for loss | Implicit TRL formatting path in notebook evidence; no explicit completion-only collator or response template captured |
+| Dataset/corpus | `train.csv`, `problems.jsonl`, deterministic `reasoning/`, synthetic `augmentations/`, and `corpus.jsonl` segment files | Kaggle notebook evidence focuses on Tong-style CoT SFT formatting and Kaggle-hosted inputs |
+| Eval/metrics | Per-epoch logprobs and token-weighted metrics on unmasked tokens; deterministic solver script reports per-category accuracy/runtime | Local notebook evidence captures training recipe and packaging checks, not a reusable repo-local eval normalizer |
+| Packaging | Modal script downloads Tinker checkpoint, finds `adapter_config.json` and `adapter_model.safetensors`, then uploads a Kaggle model version | Minimal `submission.zip` with `adapter_config.json` and `adapter_model.safetensors` at root |
+| Augmentation/weighting | Generators for spelling, concatenation, splitting, matching, and lstrip; supports CE, weighted CE, importance sampling, PPO, CISPO, and DRO-style losses | Priority/upweighting ideas are present in notebook evidence but tied to Kaggle input paths |
+| Solver/teacher pattern | Category reasoners generate deterministic natural-language CoT traces and keep traces only when extracted answer matches the stored answer | Tong-style CoT formatting is the reusable pattern; source/commit/license capture still required before porting |
+
+## Adopt / Reject / Gate
+
+| Decision | Item | Rationale | Downstream |
+|---|---|---|---|
+| Adopt | `#14` official facts as defaults | Official Kaggle/NVIDIA facts override public baselines. | All downstream issues |
+| Adopt | konbu17 minimal zip layout | Matches the frozen root-only adapter package contract. Keep provenance outside the zip. | `#20` |
+| Adopt | `r=32` as SFT-safe LoRA rank | Matches konbu17 and the official `r <= 32` cap. Removes stale `r=64` plan assumptions. | `#25` |
+| Reject | Implicit/default masking | TRL defaults can drift by version. Require explicit completion-only masking in our SFT implementation. | `#25` |
+| Gate | konbu17 9-module target set | Useful experiment candidate, but official demo references only 4 modules. Requires PM signoff before expanding. | `#25` |
+| Gate | Tong augmentation and weighting ideas | Promising but must capture exact source files, commit SHA, and license/provenance before implementation. | `#24`, `#25` |
+| Gate | Tong solver/teacher patterns | Solver-first deterministic CoT is relevant, but should be translated into project-owned interfaces and tests. | `#23`, `#24`, `#25` |
+
+## Evidence Notes
+
+- Tong repo commit used for review:
+  `82bd1880aa8a8986ad572ccd17ae35b2b5c7da85`.
+- Public Tong README identifies the repository as a Progress Prize submission and
+  lists the training sequence:
+  <https://github.com/tonghuikang/nemotron>.
+- Key Tong files reviewed:
+  `train_sft.py`, `train_common.py`, `corpus.py`, `reasoning.py`,
+  `augmentation.py`, `loss_config.py`, `upload_adapter.py`.
+- konbu17 public URL:
+  <https://www.kaggle.com/code/konbu17/nemotron-tong-style-cot-sft-updated-v2>.
+  The live Kaggle page did not expose notebook cell text in this environment,
+  so konbu17 details above come from existing repo-local notebook evidence.
+- Official Kaggle/NVIDIA discussion/demo URL:
+  <https://www.kaggle.com/competitions/nvidia-nemotron-model-reasoning-challenge/discussion/687547>.
+  Use `docs/architecture/COMPETITION.md` as the repo's frozen `#14` artifact.

--- a/docs/execution/NOTEBOOKS.md
+++ b/docs/execution/NOTEBOOKS.md
@@ -32,15 +32,15 @@ Every local notebook must include the following sections inside the notebook:
 |---|---|---|---|
 | `notebooks/00_competition_constraints_and_rules.ipynb` | `#14` | Verify rules, model constraints, evaluation rules, and deadlines | validated |
 | `notebooks/01_external_baselines_and_design_deltas.ipynb` | `#16` | Compare Tong, `konbu17`, and current repo assumptions | validated |
-| `notebooks/02_dataset_schema_and_eda.ipynb` | `#17` | Explain dataset schema, category shape, and normalization plan | validated |
-| `notebooks/03_validation_and_golden_set.ipynb` | `#18` | Define validation split and golden-set regression policy | validated |
+| `notebooks/02_dataset_schema_and_eda.ipynb` | `#17` | Explain dataset schema, category shape, and normalization plan | scaffolded |
+| `notebooks/03_validation_and_golden_set.ipynb` | `#18` | Define validation split and golden-set regression policy | scaffolded |
 | `notebooks/04_baseline_eval_and_normalization.ipynb` | `#19` | Define exact-match eval records and normalization rules | active |
 | `notebooks/05_prompting_and_decode_sweeps.ipynb` | `#21` | Compare prompt templates and decode settings; writes ranked sweep CSV + findings doc | active |
 | `notebooks/06_trajectory_collection_and_error_slices.ipynb` | `#22` | Document failure slices and targeted follow-up loops | scaffolded |
 | `notebooks/07_solver_framework_design.ipynb` | `#23` | Specify the category-aware solver interface and fallback policy | scaffolded |
 | `notebooks/08_synthetic_data_recipe.ipynb` | `#24` | Specify teacher, filter, and provenance rules for synthetic data | scaffolded |
 | `notebooks/09_sft_runbook_and_masking.ipynb` | `#25` | Specify LoRA/QLoRA runbook, masking, and checkpoint policy | scaffolded |
-| `notebooks/10_submission_packaging_and_provenance.ipynb` | `#20` | Specify packaging, dry-run validation, and provenance metadata | validated |
+| `notebooks/10_submission_packaging_and_provenance.ipynb` | `#20` | Specify packaging, dry-run validation, and provenance metadata | scaffolded |
 
 ## Cross-Notebook Architectural Decisions
 

--- a/docs/execution/NOTEBOOKS.md
+++ b/docs/execution/NOTEBOOKS.md
@@ -50,10 +50,10 @@ Every local notebook must include the following sections inside the notebook:
   - Load recipe: `trust_remote_code=True`, `torch.bfloat16`, `device_map="auto"`
   - LoRA rank cap: `r ≤ 32` (evaluator enforces `max_lora_rank=32`)
   - Demo target modules: `in_proj|out_proj|up_proj|down_proj`
-  - Scoring: extract from `\\boxed{}`, exact match (or `1e-3` numeric tolerance); reasoning text outside the box is allowed and ignored
+  - Scoring: extract from `\boxed{}`, exact match (or `1e-3` numeric tolerance); reasoning text outside the box is allowed and ignored
   - Submission zip: `adapter_config.json` + `adapter_model.safetensors` at root
   - Evaluator decode: `max_tokens=7680`, `temperature=0.0`, `top_p=1.0`, `max_model_len=8192`
-- Notebooks must use `\\boxed{}` extraction for normalization and not assume plain raw-string answers.
+- Notebooks must use `\boxed{}` extraction for normalization and not assume plain raw-string answers.
 - Keep explanation and citations inside the notebook so non-technical reviewers can read one artifact end-to-end.
 
 ## External Reference Work

--- a/docs/execution/NOTEBOOKS.md
+++ b/docs/execution/NOTEBOOKS.md
@@ -65,6 +65,8 @@ Every local notebook must include the following sections inside the notebook:
 | https://www.kaggle.com/datasets/kishanvavdara/nemotron-reasoning-traj | Useful for failure-slice and trajectory analysis patterns |
 | https://aitherium.com/blog/nemotron-reasoning-challenge-mirothinker-distillation/ | Public distillation notes and design pitfalls |
 
+Current bounded review artifact: `docs/analysis/EXTERNAL_BASELINE_REVIEW.md`.
+
 ## Update Procedure
 
 - Update this file whenever a notebook changes state from `scaffolded` to `active`, `validated`, or `superseded`.

--- a/docs/learn/project/implemented-today.md
+++ b/docs/learn/project/implemented-today.md
@@ -34,6 +34,9 @@ work in four broad areas:
 - prompt and decode sweep helpers (deterministic run-id construction, sparse grid
   expansion, Best-of-N majority vote, aggregate CSV writing, findings markdown
   rendering)
+- a bounded external-baseline review artifact for Tong (`tonghuikang`) and
+  konbu17, with Adopt / Reject / Gate decisions tied back to the verified
+  Kaggle/NVIDIA contract
 
 That means the repo is no longer just planning documents. It now contains real
 Python modules for contracts, evaluation, packaging, and prompt sweeping, along
@@ -55,6 +58,9 @@ with tests for each.
   `data/eval/golden_20.jsonl`) are not yet present in the repo.
 - `src/inference/submission.py` shows that the packaging path is implemented in
   code, not only discussed in planning docs.
+- `docs/analysis/EXTERNAL_BASELINE_REVIEW.md` records the current external
+  baseline review and keeps public reference choices subordinate to the official
+  `#14` competition contract.
 
 ## Why This Matters
 
@@ -69,3 +75,4 @@ and solver work will build on.
 - Repo: [src/contracts.py](../../../src/contracts.py)
 - Repo: [src/evaluation/runner.py](../../../src/evaluation/runner.py)
 - Repo: [src/inference/submission.py](../../../src/inference/submission.py)
+- Repo: [docs/analysis/EXTERNAL_BASELINE_REVIEW.md](../../analysis/EXTERNAL_BASELINE_REVIEW.md)

--- a/docs/learn/project/in-progress.md
+++ b/docs/learn/project/in-progress.md
@@ -26,8 +26,8 @@ finished, stable delivery.
 
 The biggest unfinished work falls into three groups:
 
-- external facts that still need confirmation, especially around competition
-  constraints and exact model assumptions
+- remaining external-source follow-up, especially source/license/provenance
+  capture before any Tong or konbu17 idea becomes implementation work
 - future implementation waves that have plan docs or notebook scaffolds, but not
   finished production code
 - the prompt/decode sweep workflow: the implementation is complete and tested,
@@ -36,8 +36,9 @@ The biggest unfinished work falls into three groups:
 
 ## Current Repo Evidence
 
-- `docs/architecture/COMPETITION.md` still marks some competition facts as open
-  questions or assumptions rather than fully frozen truths.
+- `docs/architecture/COMPETITION.md` now captures the verified `#14` contract
+  for the base model path, boxed-answer scoring, rank cap, and root zip layout;
+  a few evaluator-internal details remain intentionally unconfirmed.
 - `docs/execution/SPRINTS.md` shows Waves C and D as downstream work that
   depends on the Wave B foundation.
 - `docs/execution/NOTEBOOKS.md` marks notebook 05 (`05_prompting_and_decode_sweeps.ipynb`)
@@ -47,6 +48,10 @@ The biggest unfinished work falls into three groups:
   explicitly: the notebook requires `data/eval/validation_200.jsonl` and
   `data/eval/golden_20.jsonl` from issue #18, which are not yet committed to the
   repo. Execution will produce ranked sweep results once those files exist.
+- `docs/analysis/EXTERNAL_BASELINE_REVIEW.md` records the completed bounded
+  Tong (`tonghuikang`) + konbu17 baseline review. Follow-up reproduction work is
+  still gated on source availability, license/provenance capture, and PM signoff
+  for deviations from the verified `#14` contract.
 - `docs/execution/plans/issue-25-hpc-queue-runbook.md` exists as a planning
   artifact, but the corresponding training work is still gated on earlier
   phases.
@@ -64,4 +69,5 @@ training execution should be described as completed work.
 - Repo: [docs/architecture/COMPETITION.md](../../architecture/COMPETITION.md)
 - Repo: [docs/execution/plans/issue-25-hpc-queue-runbook.md](../../execution/plans/issue-25-hpc-queue-runbook.md)
 - Repo: [docs/analysis/prompting_findings.md](../../analysis/prompting_findings.md)
+- Repo: [docs/analysis/EXTERNAL_BASELINE_REVIEW.md](../../analysis/EXTERNAL_BASELINE_REVIEW.md)
 - Repo: [src/evaluation/prompt_sweeps.py](../../../src/evaluation/prompt_sweeps.py)

--- a/docs/learn/project/planned-roadmap.md
+++ b/docs/learn/project/planned-roadmap.md
@@ -26,7 +26,9 @@ The next major steps in the repo’s roadmap are:
 - failure-slice and trajectory collection (notebook 06, scaffolded)
 - solver-framework design (notebook 07, scaffolded)
 - synthetic-data design (notebook 08, scaffolded)
-- SFT and masking runbooks for training (notebook 09, scaffolded)
+- SFT and masking runbooks for training (notebook 09, scaffolded), using
+  `r<=32`, explicit completion-only masking, and the verified `#14` base
+  model/package contract
 
 Note: prompt and decode experiments are no longer purely planned. The
 implementation in `src/evaluation/prompt_sweeps.py` and notebook 05 exist and
@@ -36,6 +38,10 @@ are tested. Execution is blocked only on split artifact availability from issue
 These remaining items are meaningful next steps, but they should be described as
 planned work until the repo contains finished deliverables and validation for
 them.
+
+External baseline ideas from Tong (`tonghuikang`) and konbu17 are now reviewed,
+but implementation remains planned work unless the idea is validated locally and
+does not drift from the official Kaggle/NVIDIA contract.
 
 ## Current Repo Evidence
 

--- a/docs/planning/notebooks/01_external_baselines_and_design_deltas.md
+++ b/docs/planning/notebooks/01_external_baselines_and_design_deltas.md
@@ -3,54 +3,52 @@
 **Parent Issue**: `#16`
 **Plan Phase**: Phase 1 (baseline) + Phase 4 (SFT)
 **Scaffold**: `notebooks/01_external_baselines_and_design_deltas.ipynb`
-**Status**: `scaffolded`
-**Dependencies (upstream)**: `#13` (template)
+**Status**: `validated`
+**Dependencies (upstream)**: `#13` (template); `#14` is the verified official contract source, not a blocker
 **Consumers (downstream)**: `#19` (baseline eval), `#23` (solver), `#25` (SFT runbook)
 
 ---
 
 ## 1. Objective
 
-Compare four external reference implementations (Tong, konbu17, Kishan, aitherium) against plan_v0.2 assumptions to extract transferable ideas for masking, augmentation, trajectory capture, and distillation. Produce a delta matrix documenting {approach, dataset, masking, eval, outcome} for each source with adoption decisions and implementation risk/cost scores. Output a prioritized decision log as `experiments/external_review_matrix.csv`.
+Compare the bounded external reference set for `#16`: Tong (`tonghuikang/nemotron`) and konbu17. Kishan and aitherium remain optional future references. The review extracts transferable ideas for masking, augmentation, solver/teacher patterns, packaging, and SFT defaults, then records adoption decisions in `docs/analysis/EXTERNAL_BASELINE_REVIEW.md`.
 
 ## 2. Why It Matters
 
-- **Leaderboard impact**: Public winners' techniques (ConstitutionalAI masking, synthetic trajectory augmentation) may transfer to private test set; incorrectly copying them risks overfitting or license friction.
+- **Leaderboard impact**: Public reference techniques may transfer to private test set; incorrectly copying them risks overfitting, rule drift, or license/provenance friction.
 - **Capstone learning**: Comparing external code teaches pattern recognition in real LoRA pipelines versus theory.
 - **Downstream coupling**: Notebooks 04, 07, 09 depend on this review to lock masking strategy and eval rules before training loops begin.
 
 ## 3. Strategy — How We Aim To Accomplish It
 
-1. **Clone or skim each repository** (Tong via GitHub, konbu17 + Kishan via Kaggle snapshot API, aitherium via blog summary) and extract {base model, dataset version, masking method, eval metric, final score} for each.
-2. **Tabulate in a delta matrix** (4 rows × 6 columns: source, approach, dataset, masking, eval, outcome).
-3. **Map each finding to plan_v0.2 phase** (Phase 1: baseline prompt & eval; Phase 4: LoRA + SFT masking rules).
-4. **Score relevance (1–5), implementation risk (1–5), re-implementation cost in hours (1–40)** for each cell; rank by (relevance − 0.5 × risk) / cost.
-5. **Record adoption decisions** with ≤2-sentence justification and upstream citation; mark "adopt," "adapt," or "reject" with downstream notebook mapping.
+1. **Review Tong (`tonghuikang/nemotron`)** from GitHub and extract base model, masking, dataset/corpus, evaluation, packaging, augmentation, weighting, and solver/teacher patterns.
+2. **Review konbu17** from the public Kaggle notebook URL and existing repo-local notebook evidence for base model, load recipe, LoRA config, target modules, masking behavior, dataset, eval protocol, and packaging.
+3. **Anchor decisions to `#14`** so the Kaggle/NVIDIA official contract is the default when external baselines differ.
+4. **Record Adopt / Reject / Gate decisions** with downstream issue mapping in `docs/analysis/EXTERNAL_BASELINE_REVIEW.md`.
 
 ## 4. MVP (Minimum Viable Notebook)
 
-- **Inputs**: GitHub/Kaggle snapshots of Tong, konbu17 repos; blog link for aitherium; public Kishan dataset metadata.
+- **Inputs**: Tong GitHub repo, konbu17 Kaggle notebook URL, existing repo-local konbu17 evidence, and `docs/architecture/COMPETITION.md`.
 - **Cells**:
   1. Environment check and repo clone/API fetch
   2. Extract config/training script signatures from each source
-  3. Build delta matrix (markdown table, then CSV export)
-  4. Score and rank rows by adoption priority
-  5. Write decision log with citations
-  6. Commit `experiments/external_review_matrix.csv` and matrix markdown cell output
-- **Outputs**: `experiments/external_review_matrix.csv`; inline markdown table; decision log as notebook cell text.
-- **Verification**: Every row has dated URL + plan-phase mapping; every "adopt" row lists downstream notebook ID.
+  3. Build a markdown decision matrix
+  4. Write Adopt / Reject / Gate decisions with downstream issue mapping
+  5. Commit `docs/analysis/EXTERNAL_BASELINE_REVIEW.md`
+- **Outputs**: `docs/analysis/EXTERNAL_BASELINE_REVIEW.md`.
+- **Verification**: Every decision names a downstream issue and does not override the verified `#14` contract.
 
 ## 5. Test Cases
 
 ### 5.1 Primary (MVP path)
 
-- **Setup**: Tong repo cloneable from GitHub; konbu17 notebook publicly readable; aitherium blog accessible; Kishan dataset visible on Kaggle.
+- **Setup**: Tong repo cloneable from GitHub; konbu17 notebook publicly readable or covered by repo-local evidence.
 - **Action**: Cells fetch repo metadata, extract masking/eval approach from each source's training script or markdown README.
-- **Expected**: Delta matrix with all 4 rows populated, each containing {source name, masking strategy, eval metric, outcome score, adoption decision}; no empty cells in "approach" or "masking" columns.
+- **Expected**: Delta matrix covers Tong and konbu17, including source identity, masking strategy, eval/metric notes, packaging, and adoption decision.
 
 ### 5.2 Alternative / Fallback
 
-If a source code becomes private (konbu17 Kaggle notebook deleted, Kishan dataset restricted):
+If a source becomes private or unextractable:
 - **Setup**: Archive links or PDF snapshots available from prior Kaggle snapshot API call.
 - **Action**: Cells extract decision from description-level metadata (public notebook metadata API, blog post summary, arXiv abstract) instead of source code inspection.
 - **Expected**: Row marked "evidence incomplete"; masking/approach columns filled from abstract or notebook title/description only; decision logic explicitly flags as "inference from public claim only."
@@ -63,35 +61,32 @@ If a source code becomes private (konbu17 Kaggle notebook deleted, Kishan datase
 
 ## 6. Success Criteria (Done When)
 
-- [ ] All 4 external sources (Tong, konbu17, Kishan, aitherium) have row entries in the delta matrix.
-- [ ] Every row has a dated URL citation, plan-phase mapping, and adoption decision with ≤2-sentence rationale.
-- [ ] At least one "adopt" decision with downstream notebook ID; at least one "reject" decision with risk justification.
-- [ ] `experiments/external_review_matrix.csv` committed with columns: `source | approach | dataset | masking_strategy | eval_metric | outcome | adoption_decision | downstream_notebook | risk_score | cost_hours | decision_rationale | citation_url | citation_date`.
-- [ ] No breaking changes to plan_v0.2 baseline assumptions without a corresponding GitHub issue.
-- [ ] Artifact(s) committed and linked in `docs/execution/NOTEBOOKS.md`.
+- [x] Tong and konbu17 have entries in the review artifact.
+- [x] The review distinguishes public reference baselines from official Kaggle/NVIDIA sources.
+- [x] At least one Adopt, Reject, and Gate decision is recorded with downstream issue mapping.
+- [x] `docs/analysis/EXTERNAL_BASELINE_REVIEW.md` is committed as the review artifact.
+- [x] No external baseline overrides the verified `#14` contract.
+- [x] Artifact is linked in `docs/execution/NOTEBOOKS.md`.
 
 ## 7. Risks & Open Questions
 
-- **Risk: Leaderboard overfitting** | **Mitigation**: Flag any technique that directly copies public winner masking as "high specificity risk"; default to reject unless re-implementation cost ≤ 4 hours and relevance ≥ 4/5.
+- **Risk: Leaderboard overfitting** | **Mitigation**: Flag any technique that directly copies public reference behavior as "high specificity risk"; default to gate unless it is backed by local validation.
 - **Risk: License incompatibility** | **Mitigation**: Audit Tong repo LICENSE file; if GPL or incompatible with repo license, mark adoption as "forbidden" and document in decision log.
-- **Risk: Kaggle dataset restricted** | **Mitigation**: Check Kishan dataset access level before execution; if access denied, switch to fallback (metadata-only delta, mark "evidence incomplete").
-- **Open question: Does Tong's ConstitutionalAI masking generalize to private test set?** | **Who answers**: Phase 4 checkpoint; compare Phase 1 baseline vs. Phase 4 SFT with adopted masking on golden set.
+- **Risk: Kaggle notebook extraction restricted** | **Mitigation**: Use repo-local evidence only when it already captures exact notebook facts; otherwise mark the source evidence incomplete.
+- **Open question: Do Tong's augmentation, weighting, and solver-first teacher patterns generalize to private test set?** | **Who answers**: Phase 4 checkpoint after source/commit/license capture and local validation.
 
 ## 8. Artifacts & Handoff
 
 - **Produces**:
-  - `experiments/external_review_matrix.csv` — main delta table
-  - Inline markdown table in notebook cell (rendered for quick review)
-  - Decision log summary (notebook markdown cell)
+  - `docs/analysis/EXTERNAL_BASELINE_REVIEW.md` — main review and decision table
 - **Consumed by**:
   - `#19` (04_baseline_eval): Confirms eval metric alignment from Tong/konbu17
-  - `#23` (07_solver): Trajectory augmentation patterns from Kishan dataset analysis
-  - `#25` (09_sft_runbook): Masking strategy and distillation safeguards from aitherium review
+  - `#23` (07_solver): Tong solver/teacher patterns
+  - `#24` (08_synthetic_data): Tong augmentation patterns
+  - `#25` (09_sft_runbook): masking strategy, LoRA rank, target-module gates
 - **External references cited**:
-  - https://github.com/tonghuikang/nemotron (commit SHA or release tag at review date)
+  - https://github.com/tonghuikang/nemotron (commit SHA captured in review artifact)
   - https://www.kaggle.com/code/konbu17/nemotron-tong-style-cot-sft-updated-v2 (kernel version / last edit date)
-  - https://www.kaggle.com/datasets/kishanvavdara/nemotron-reasoning-traj (dataset version / last update date)
-  - https://aitherium.com/blog/nemotron-reasoning-challenge-mirothinker-distillation/ (blog publish date)
 
 ## 9. Estimated Effort
 

--- a/docs/planning/notebooks/09_sft_runbook_and_masking.md
+++ b/docs/planning/notebooks/09_sft_runbook_and_masking.md
@@ -11,7 +11,7 @@
 
 ## 1. Objective
 
-Codify the LoRA/QLoRA training runbook before executing long runs on the HPC cluster: specify target modules (q_proj, v_proj for Transformer; x_proj, in_proj, out_proj for Mamba-2), implement loss masking so gradients only flow on reasoning tokens and completions (not prompts), define checkpoint and early-stopping policies, and produce two configuration files (full LoRA for HPC, QLoRA 4-bit for Colab/local) plus a minimal smoke-test training run (100 steps) that validates the entire pipeline on a 1k curated subset.
+Codify the LoRA/QLoRA training runbook before executing long runs on the HPC cluster: default to the verified `#14` base model and `r <= 32`, start from the official 4-module demo target set (`in_proj`, `out_proj`, `up_proj`, `down_proj`), gate any broader konbu17-style target set behind PM signoff, implement explicit completion-only masking so prompt/user tokens are ignored by loss, define checkpoint and early-stopping policies, and produce configuration files plus a minimal smoke-test training run that validates the entire pipeline on a small curated subset.
 
 ## 2. Why It Matters
 
@@ -22,16 +22,16 @@ Codify the LoRA/QLoRA training runbook before executing long runs on the HPC clu
 
 ## 3. Strategy — How We Aim To Accomplish It
 
-1. **Confirm LoRA target modules by introspection**: Load base model, dump `model.named_modules()`, match against q_proj, v_proj (Transformer), x_proj, in_proj, out_proj (Mamba-2); document exact module names in `configs/lora_baseline.yaml`.
+1. **Confirm LoRA target modules by introspection**: Load the verified `#14` base model, dump `model.named_modules()`, start from the official demo set (`in_proj`, `out_proj`, `up_proj`, `down_proj`), and document any proposed expansion separately for PM signoff.
 2. **Verify tokenizer chat template and reasoning tokens**: Confirm `<think>` = token 12, `</think>` = token 13; validate that `apply_chat_template(..., enable_thinking=True)` produces expected token sequences.
 3. **Implement loss masking**: Write masking utility to set prompt token labels to -100 (ignored by loss), keep reasoning/answer tokens; unit test with synthetic input showing correct -100 mask alignment.
-4. **Codify LoRA configs**: Write `configs/lora_baseline.yaml` (r=64, alpha=128, dropout=0.05, bias="none", task_type="CAUSAL_LM") for HPC full LoRA; write `configs/lora_qlora.yaml` with 4-bit quantization for Colab.
+4. **Codify LoRA configs**: Write `configs/lora_baseline.yaml` with `r=32` or lower, bf16, explicit target modules, dropout/bias/task type, and completion-only masking; write `configs/lora_qlora.yaml` with 4-bit quantization for Colab/local smoke tests.
 5. **Define checkpoint/early-stopping policy**: Log checkpoint intervals (every 500 steps), eval interval (every 100 steps), early-stopping patience (3 evals without improvement), validation on golden_20.
 6. **Smoke-run sign-off**: Execute 100-step training on 1k curated subset using Unsloth on RTX 3080 with QLoRA, log loss curve to WandB, verify golden_20 pass rate ≥ 100%, save adapter as safetensors and load it back.
 
 ## 4. MVP (Minimum Viable Notebook)
 
-**Inputs**: Base model (4B BF16), 1k curated samples from #24, golden_20 validation set, requirements.txt pinning torch/transformers/peft/unsloth/trl.
+**Inputs**: Verified `#14` base model, 1k curated samples from #24, golden_20 validation set, requirements.txt pinning torch/transformers/peft/unsloth/trl.
 
 **Cells**:
 - Cell 1: Environment check (GPU, torch, transformers versions)
@@ -79,7 +79,7 @@ If Unsloth does not support the hybrid Mamba-2 + Transformer architecture on ins
 
 ## 6. Success Criteria (Done When)
 
-- [ ] `configs/lora_baseline.yaml` written with verified target module names (q_proj, v_proj, x_proj, in_proj, out_proj)
+- [ ] `configs/lora_baseline.yaml` written with `r<=32`, verified target module names, and PM signoff for any expansion beyond the official 4-module demo set
 - [ ] `configs/lora_qlora.yaml` written with 4-bit quantization params
 - [ ] `src/training/sft_trainer.py` contains masking utility; all prompt tokens set to label=-100
 - [ ] `tests/test_masking.py` passes with 100% prompt coverage in unit tests
@@ -109,7 +109,7 @@ If Unsloth does not support the hybrid Mamba-2 + Transformer architecture on ins
 ## 8. Artifacts & Handoff
 
 **Produces**:
-- `configs/lora_baseline.yaml` — Full LoRA (r=64, alpha=128) for HPC
+- `configs/lora_baseline.yaml` — Full LoRA (`r<=32`) for HPC
 - `configs/lora_qlora.yaml` — QLoRA 4-bit for Colab/RTX 3080
 - `src/training/sft_trainer.py` — SFT trainer wrapper + masking logic
 - `tests/test_masking.py` — Unit tests for loss masking (prompt -100 alignment)

--- a/docs/planning/notebooks/10_submission_packaging_and_provenance.md
+++ b/docs/planning/notebooks/10_submission_packaging_and_provenance.md
@@ -22,7 +22,7 @@ Implement a reproducible, verifiable submission pipeline that packages a LoRA ad
 
 ## 3. Strategy — How We Aim To Accomplish It
 
-1. **Enumerate competition-required files** from `#14` frozen constraints: adapter weights (safetensors), config.json, README.md, optional metadata.json.
+1. **Enumerate competition-required files** from `#14` frozen constraints: `adapter_config.json` and `adapter_model.safetensors` at the zip root. Keep README, manifest, and provenance metadata outside the submitted zip.
 2. **Implement `package(adapter_path, output_dir, config_dict)`**: copy adapter → compute SHA256 hash → write manifest.json (schema validated) → zip bundle.
 3. **Implement `dry_run(base_model, adapter_path, dry_run_config)`**: load base + adapter, run Phase 1.2 smoke test (2^10 mod 7), verify output format.
 4. **Run golden_20 validation**: load golden_20 from `data/eval/golden_20.jsonl`, verify all 20 pass (100% accuracy requirement); fail immediately if any drop.
@@ -62,7 +62,7 @@ Implement a reproducible, verifiable submission pipeline that packages a LoRA ad
 
 - **Setup**: Base model loaded, dummy (null identity) adapter created, golden_20.jsonl and validation_200.jsonl present
 - **Action**: Call `package(adapter, "submissions/2026-04-20_test/")` → call `dry_run_smoke_test()` → call `dry_run_golden_set()` → call `dry_run_validation_slice()`
-- **Expected**: Manifest JSON written; all three dry-run checks pass; golden_20 accuracy = 20/20; validation_50 mean accuracy within ±2σ of `#19` baseline; zip contains adapter_model.safetensors, manifest.json, README.md
+- **Expected**: Manifest JSON written outside the zip; all three dry-run checks pass; golden_20 accuracy = 20/20; validation_50 mean accuracy within +/-2 sigma of `#19` baseline; zip contains only `adapter_config.json` and `adapter_model.safetensors` at root.
 
 ### 5.2 Alternative / Fallback
 
@@ -93,9 +93,9 @@ Implement a reproducible, verifiable submission pipeline that packages a LoRA ad
 
 - **Risk**: Competition format changes between `#14` freeze (April 2026) and submission deadline → **Mitigation**: Pluggable packager abstraction in submission.py; implement CompetitionFormatV1 class; v2 format can be added without breaking training code.
 - **Risk**: Timezone drift on deadline (uploaded manifest timestamp vs Kaggle server clock) → **Mitigation**: Use UTC timestamps, include timezone in manifest, document Kaggle deadline in submission checklist.
-- **Risk**: Adapter size exceeds competition max (check `#14`; assume ~30-50 MB for safetensors) → **Mitigation**: Pre-flight check in packaging; raise exception if > limit; document limit in checklist.
+- **Risk**: Adapter size exceeds unconfirmed competition max (no explicit file-size limit found in `#14`) → **Mitigation**: Pre-flight check in packaging; warn if adapter is unusually large and monitor real submission feedback.
 - **Risk**: Final submitted adapter differs in SHA256 from dry-run (accidental overwrite, file corruption) → **Mitigation**: Compute hash before zipping; store in manifest; re-hash after zip and verify; prevent re-upload of same adapter without explicit confirmation.
-- **Open question**: Does Kaggle accept optional metadata.json alongside safetensors or require a specific format? → **Who answers**: Review `#14` frozen constraints and Kaggle submission demo notebook; hard-code format based on demo.
+- **Resolved question**: Kaggle demo requires root `adapter_config.json` and `adapter_model.safetensors`; do not include optional metadata or README inside `submission.zip` unless the official contract changes.
 
 ## 8. Artifacts & Handoff
 

--- a/docs/planning/plan_v0.2.md
+++ b/docs/planning/plan_v0.2.md
@@ -97,7 +97,7 @@ CS4650-Nvidia-Nemotron-Challenge/
 ├── .gitignore                    # Exclude data/, adapters/*.safetensors, .env
 │
 ├── configs/                      # Training configurations
-│   ├── lora_baseline.yaml        # LoRA r=64, alpha=128
+│   ├── lora_baseline.yaml        # LoRA r=32, alpha=32 (#14 rank cap)
 │   ├── lora_qlora.yaml           # QLoRA 4-bit for consumer GPUs
 │   ├── grpo_config.yaml          # GRPO RL training
 │   └── data_curation.yaml        # NeMo Curator config
@@ -415,13 +415,13 @@ python main.py \
 **Requires**: Phase 3 curated dataset ready, validation set reserved
 **Hardware**: **HPC cluster** (primary) or Colab Pro with QLoRA (fallback)
 
-### 4.1 LoRA Configuration (NVIDIA Recommended)
+### 4.1 LoRA Configuration (Verified #14 Contract)
 ```python
 from peft import LoraConfig
 
 lora_config = LoraConfig(
-    r=64,                          # Rank (sweet spot per NVIDIA)
-    lora_alpha=128,                # Alpha = 2x rank
+    r=32,                          # Max rank allowed by verified #14 contract
+    lora_alpha=32,                 # Match konbu17-safe baseline; tune only after PM signoff
     target_modules=[
         "q_proj", "v_proj",        # Transformer attention layers
         "x_proj", "in_proj", "out_proj"  # Mamba-2 layers


### PR DESCRIPTION
Introduce doc orchestration helpers and a bounded external-baseline review.

Adds new .claude agent specs (architecture-sync, doc-orchestrator, execution-sync, learn-sync, routing-sync) and a doc-sync command; update .gitignore to ignore .claude/*.log.

Add docs/analysis/EXTERNAL_BASELINE_REVIEW.md and wire the review into execution and learning docs by updating NOTEBOOKS.md, TODO.md, and several learn/planning files to reflect the verified #14 competition contract (boxed-answer scoring, base model/load recipe, r<=32, 4-module demo target, root zip layout).

 Update SFT runbook, packaging and provenance notes to enforce explicit completion-only masking, LoRA rank constraints, and submission packaging rules (adapter_config.json + adapter_model.safetensors at zip root).