### PR TITLE
feat(#17, #18): dataset ingestion, EDA, and split artifacts

### DIFF
--- a/notebooks/02_dataset_schema_and_eda.ipynb
+++ b/notebooks/02_dataset_schema_and_eda.ipynb
@@ -39,11 +39,12 @@
    "source": [
     "## Environment and Reproduction\n",
     "\n",
-    "            This notebook is scaffolded to execute cleanly before the implementation code exists.\n",
-    "\n",
     "- Python: 3.7.9 (tested); 3.11+ recommended for full src/ compatibility\n",
-    "- Run from repo root or open directly in Jupyter\n",
-    "- Expected companion issue and registry entry: `docs/execution/NOTEBOOKS.md`\n"
+    "- Run from repo root: `jupyter notebook` from `CS4650-Nvidia-Nemotron-Challenge/`\n",
+    "- Notebook uses `Path.cwd().parent` to resolve repo root when launched from `notebooks/`\n",
+    "- Input: `data/raw/train.csv` (download from Kaggle competition data tab after joining)\n",
+    "- Output: `data/eval/train_normalized.jsonl` (git-ignored, input for notebook 03)\n",
+    "- Companion issue and registry entry: `docs/execution/NOTEBOOKS.md`"
    ]
   },
   {

--- a/notebooks/02_dataset_schema_and_eda.ipynb
+++ b/notebooks/02_dataset_schema_and_eda.ipynb
@@ -1,139 +1,460 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "id": "overview",
-      "metadata": {},
-      "source": [
-        "# 02. Dataset Schema and EDA\n",
-        "\n",
-        "- Parent issue: `#17`\n",
-        "- Status: `scaffolded`\n",
-        "- Summary: Explain the dataset shape, category mix, and normalization contract before code paths hard-code assumptions.\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "audience",
-      "metadata": {},
-      "source": [
-        "## Audience and Why It Matters\n",
-        "\n",
-        "Data contributors, reviewers, and non-technical readers who need to see what the benchmark actually looks like.\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "decision",
-      "metadata": {},
-      "source": [
-        "## Decision / Hypothesis\n",
-        "\n",
-        "Normalize all dataset sources into the shared `ReasoningExample` contract and emphasize category-specific task shape over generic math-only framing.\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "environment",
-      "metadata": {},
-      "source": [
-        "## Environment and Reproduction\n",
-        "\n",
-        "            This notebook is scaffolded to execute cleanly before the implementation code exists.\n",
-        "\n",
-        "- Python: 3.11+\n",
-        "- Run from repo root or open directly in Jupyter\n",
-        "- Expected companion issue and registry entry: `docs/execution/NOTEBOOKS.md`\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "environment-check",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "from pathlib import Path\n",
-        "import platform\n",
-        "\n",
-        "REPO_ROOT = Path.cwd()\n",
-        "\n",
-        "print(f\"Repo root: {REPO_ROOT}\")\n",
-        "print(f\"Python platform: {platform.platform()}\")\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "method",
-      "metadata": {},
-      "source": [
-        "## Method and Outputs\n",
-        "\n",
-        "            ### Planned method\n",
-        "            - Inspect the official dataset or mirror columns and sample prompts.\n",
-        "- Document category distribution and the input/output format.\n",
-        "- Show how raw records map into the canonical schema.\n",
-        "\n",
-        "            ### Expected outputs\n",
-        "            - Schema mapping examples\n",
-        "- Category inventory\n",
-        "- Normalization checklist\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "task-list",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "planned_tasks = [\n",
-        "    \"replace scaffold text with verified findings\",\n",
-        "    \"link concrete artifacts produced during execution\",\n",
-        "    \"update docs/execution/NOTEBOOKS.md when status changes\",\n",
-        "]\n",
-        "\n",
-        "for item in planned_tasks:\n",
-        "    print(f\"- {item}\")\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "risks",
-      "metadata": {},
-      "source": [
-        "## Results / Open Risks\n",
-        "\n",
-        "            This scaffold intentionally records the current open questions before implementation code exists.\n",
-        "\n",
-        "            - Mirror datasets may not preserve all metadata from Kaggle.\n",
-        "- Category names and answer formatting may evolve as the official data is refreshed.\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "sources",
-      "metadata": {},
-      "source": [
-        "## Sources\n",
-        "\n",
-        "            - [Competition facts doc](docs/architecture/COMPETITION.md)\n",
-        "- [Architecture doc](docs/architecture/ARCHITECTURE.md)\n",
-        "- [HF mirror cited in repo docs](https://huggingface.co/datasets/Taurine511/nvidia-nemotron-model-reasoning-challenge)\n"
-      ]
-    }
-  ],
-  "metadata": {
-    "kernelspec": {
-      "display_name": "Python 3",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "name": "python",
-      "version": "3.11"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "overview",
+   "metadata": {},
+   "source": [
+    "# 02. Dataset Schema and EDA\n",
+    "\n",
+    "- Parent issue: `#17`\n",
+    "- Status: `active`\n",
+    "- Summary: Explain the dataset shape, category mix, and normalization contract before code paths hard-code assumptions.\n"
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 5
+  {
+   "cell_type": "markdown",
+   "id": "audience",
+   "metadata": {},
+   "source": [
+    "## Audience and Why It Matters\n",
+    "\n",
+    "Data contributors, reviewers, and non-technical readers who need to see what the benchmark actually looks like.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "decision",
+   "metadata": {},
+   "source": [
+    "## Decision / Hypothesis\n",
+    "\n",
+    "Normalize all dataset sources into the shared `ReasoningExample` contract and emphasize category-specific task shape over generic math-only framing.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "environment",
+   "metadata": {},
+   "source": [
+    "## Environment and Reproduction\n",
+    "\n",
+    "            This notebook is scaffolded to execute cleanly before the implementation code exists.\n",
+    "\n",
+    "- Python: 3.7.9 (tested); 3.11+ recommended for full src/ compatibility\n",
+    "- Run from repo root or open directly in Jupyter\n",
+    "- Expected companion issue and registry entry: `docs/execution/NOTEBOOKS.md`\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "environment-check",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Repo root : C:\\Users\\SBaroni\\CS4650-Nvidia-Nemotron-Challenge\n",
+      "Python    : 3.7.9\n",
+      "Platform  : Windows-10-10.0.26100-SP0\n"
+     ]
+    }
+   ],
+   "source": [
+    "import sys\n",
+    "import platform\n",
+    "from pathlib import Path\n",
+    "\n",
+    "_cwd = Path.cwd()\n",
+    "REPO_ROOT = _cwd\n",
+    "for _p in [_cwd] + list(_cwd.parents):\n",
+    "    if (_p / \"src\").is_dir() and (_p / \"notebooks\").is_dir():\n",
+    "        REPO_ROOT = _p\n",
+    "        break\n",
+    "if str(REPO_ROOT) not in sys.path:\n",
+    "    sys.path.insert(0, str(REPO_ROOT))\n",
+    "\n",
+    "print(f\"Repo root : {REPO_ROOT}\")\n",
+    "print(f\"Python    : {sys.version.split()[0]}\")\n",
+    "print(f\"Platform  : {platform.platform()}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "method",
+   "metadata": {},
+   "source": [
+    "## Method and Outputs\n",
+    "\n",
+    "### Planned method\n",
+    "- Inspect the official dataset or mirror columns and sample prompts.\n",
+    "- Document category distribution and the input/output format.\n",
+    "- Show how raw records map into the canonical schema.\n",
+    "\n",
+    "### Expected outputs\n",
+    " - Schema mapping examples\n",
+    "- Category inventory\n",
+    "- Normalization checklist\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "fb4caeab",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Shape   : (9500, 3)\n",
+      "Columns : ['id', 'prompt', 'answer']\n",
+      "\n",
+      "First row:\n",
+      "  id                  : '00066667'\n",
+      "  prompt              : \"In Alice's Wonderland, a secret bit manipulation rule transforms 8-bit binary numbers. The transformation involves opera\"\n",
+      "  answer              : '10010111'\n"
+     ]
+    }
+   ],
+   "source": [
+    "import pandas as pd\n",
+    "from pathlib import Path\n",
+    "\n",
+    "REPO_ROOT = Path.cwd().parent\n",
+    "df = pd.read_csv(REPO_ROOT / \"data\" / \"raw\" / \"train.csv\")\n",
+    "\n",
+    "print(f\"Shape   : {df.shape}\")\n",
+    "print(f\"Columns : {df.columns.tolist()}\")\n",
+    "print(f\"\\nFirst row:\")\n",
+    "for col, val in df.iloc[0].items():\n",
+    "    print(f\"  {col:<20}: {repr(str(val)[:120])}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "e7ff933f",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--- Row 0 ---\n",
+      "In Alice's Wonderland, a secret bit manipulation rule transforms 8-bit binary numbers. The transformation involves operations like bit shifts, rotations, XOR, AND, OR, NOT, and possibly majority or ch\n",
+      "answer: 10010111\n",
+      "\n",
+      "--- Row 1 ---\n",
+      "In Alice's Wonderland, a secret bit manipulation rule transforms 8-bit binary numbers. The transformation involves operations like bit shifts, rotations, XOR, AND, OR, NOT, and possibly majority or ch\n",
+      "answer: 01000011\n",
+      "\n",
+      "--- Row 2 ---\n",
+      "In Alice's Wonderland, secret encryption rules are used on text. Here are some examples:\n",
+      "ucoov pwgtfyoqg vorq yrjjoe -> queen discovers near valley\n",
+      "pqrsfv pqorzg wvgwpo trgbjo -> dragon dreams inside \n",
+      "answer: cat imagines book\n",
+      "\n",
+      "--- Row 3 ---\n",
+      "In Alice's Wonderland, numbers are secretly converted into a different numeral system. Some examples are given below:\n",
+      "11 -> XI\n",
+      "15 -> XV\n",
+      "94 -> XCIV\n",
+      "19 -> XIX\n",
+      "Now, write the number 38 in the Wonderland \n",
+      "answer: XXXVIII\n",
+      "\n",
+      "--- Row 4 ---\n",
+      "In Alice's Wonderland, secret encryption rules are used on text. Here are some examples:\n",
+      "wkgqa lsrqaq wneeke -> mouse chases mirror\n",
+      "wkgqa nwrjnvaq nv brmrla -> mouse imagines in palace\n",
+      "srppae oerhq gv\n",
+      "answer: wizard creates secret\n",
+      "\n",
+      "--- Row 5 ---\n",
+      "In Alice's Wonderland, a secret unit conversion is applied to measurements. For example:\n",
+      "10.08 m becomes 6.69\n",
+      "17.83 m becomes 11.83\n",
+      "35.85 m becomes 23.79\n",
+      "17.06 m becomes 11.32\n",
+      "31.54 m becomes 20.93\n",
+      "No\n",
+      "answer: 16.65\n",
+      "\n",
+      "--- Row 6 ---\n",
+      "In Alice's Wonderland, a secret bit manipulation rule transforms 8-bit binary numbers. The transformation involves operations like bit shifts, rotations, XOR, AND, OR, NOT, and possibly majority or ch\n",
+      "answer: 00110100\n",
+      "\n",
+      "--- Row 7 ---\n",
+      "In Alice's Wonderland, the gravitational constant has been secretly changed. Here are some example observations:\n",
+      "For t = 1.37s, distance = 14.92 m\n",
+      "For t = 4.27s, distance = 144.96 m\n",
+      "For t = 3.28s, dis\n",
+      "answer: 154.62\n",
+      "\n",
+      "--- Row 8 ---\n",
+      "In Alice's Wonderland, a secret set of transformation rules is applied to equations. Below are a few examples:\n",
+      "`!*[{ = '\"[`\n",
+      "\\'*'> = ![@\n",
+      "\\'-!` = \\\\\n",
+      "`!*\\& = '@'{\n",
+      "Now, determine the result for: [[-!'\n",
+      "answer: @&\n",
+      "\n",
+      "--- Row 9 ---\n",
+      "In Alice's Wonderland, the gravitational constant has been secretly changed. Here are some example observations:\n",
+      "For t = 4.85s, distance = 204.55 m\n",
+      "For t = 3.13s, distance = 85.19 m\n",
+      "For t = 1.7s, dist\n",
+      "answer: 50.51\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Look at 10 sample prompts to understand the structure\n",
+    "for i in range(10):\n",
+    "    print(f\"--- Row {i} ---\")\n",
+    "    print(df.iloc[i][\"prompt\"][:200])\n",
+    "    print(f\"answer: {df.iloc[i]['answer']}\")\n",
+    "    print()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "ff01c970",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== Category Distribution ===\n",
+      "bit_manipulation     1602\n",
+      "physics_gravity      1597\n",
+      "unit_conversion      1594\n",
+      "text_cipher          1576\n",
+      "numeral_system       1576\n",
+      "equation_symbolic    1555\n",
+      "Name: category, dtype: int64\n",
+      "\n",
+      "Unknown rows: 0\n"
+     ]
+    }
+   ],
+   "source": [
+    "import re\n",
+    "\n",
+    "def extract_category(prompt):\n",
+    "    p = str(prompt)\n",
+    "    if \"bit manipulation\" in p:\n",
+    "        return \"bit_manipulation\"\n",
+    "    elif \"encryption rules\" in p:\n",
+    "        return \"text_cipher\"\n",
+    "    elif \"numeral system\" in p:\n",
+    "        return \"numeral_system\"\n",
+    "    elif \"unit conversion\" in p:\n",
+    "        return \"unit_conversion\"\n",
+    "    elif \"gravitational constant\" in p:\n",
+    "        return \"physics_gravity\"\n",
+    "    elif \"transformation rules is applied to equations\" in p:\n",
+    "        return \"equation_symbolic\"\n",
+    "    elif \"algebraic\" in p.lower() or \"solve for\" in p.lower():\n",
+    "        return \"equation_numeric\"\n",
+    "    else:\n",
+    "        return \"unknown\"\n",
+    "\n",
+    "df[\"category\"] = df[\"prompt\"].apply(extract_category)\n",
+    "\n",
+    "print(\"=== Category Distribution ===\")\n",
+    "print(df[\"category\"].value_counts())\n",
+    "print(f\"\\nUnknown rows: {(df['category'] == 'unknown').sum()}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "64af343c",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== Prompt Length ===\n",
+      "count    9500.0\n",
+      "mean      301.5\n",
+      "std       104.3\n",
+      "min       177.0\n",
+      "25%       209.0\n",
+      "50%       281.0\n",
+      "75%       371.0\n",
+      "max       510.0\n",
+      "Name: prompt_len, dtype: float64\n",
+      "\n",
+      "=== Answer Length ===\n",
+      "count    9500.0\n",
+      "mean        8.4\n",
+      "std         8.0\n",
+      "min         1.0\n",
+      "25%         4.0\n",
+      "50%         5.0\n",
+      "75%         8.0\n",
+      "max        39.0\n",
+      "Name: answer_len, dtype: float64\n",
+      "\n",
+      "=== Missing Values ===\n",
+      "id            0\n",
+      "prompt        0\n",
+      "answer        0\n",
+      "category      0\n",
+      "prompt_len    0\n",
+      "answer_len    0\n",
+      "dtype: int64\n"
+     ]
+    }
+   ],
+   "source": [
+    "df[\"prompt_len\"] = df[\"prompt\"].str.len()\n",
+    "df[\"answer_len\"] = df[\"answer\"].str.len()\n",
+    "\n",
+    "print(\"=== Prompt Length ===\")\n",
+    "print(df[\"prompt_len\"].describe().round(1))\n",
+    "\n",
+    "print(\"\\n=== Answer Length ===\")\n",
+    "print(df[\"answer_len\"].describe().round(1))\n",
+    "\n",
+    "print(\"\\n=== Missing Values ===\")\n",
+    "print(df.isnull().sum())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "12b81616",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Answers containing \\boxed{}: 0 / 9500\n",
+      "\n",
+      "Sample answers by category:\n",
+      "  bit_manipulation         : '10010111'\n",
+      "  equation_symbolic        : '@&'\n",
+      "  numeral_system           : 'XXXVIII'\n",
+      "  physics_gravity          : '154.62'\n",
+      "  text_cipher              : 'cat imagines book'\n",
+      "  unit_conversion          : '16.65'\n"
+     ]
+    }
+   ],
+   "source": [
+    "has_boxed = df[\"answer\"].str.contains(r\"\\\\boxed\", na=False).sum()\n",
+    "print(f\"Answers containing \\\\boxed{{}}: {has_boxed} / {len(df)}\")\n",
+    "\n",
+    "print(\"\\nSample answers by category:\")\n",
+    "for cat, group in df.groupby(\"category\"):\n",
+    "    print(f\"  {cat:<25}: {repr(group.iloc[0]['answer'])}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "d967cc0e",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Wrote 9500 rows → data/eval/train_normalized.jsonl\n",
+      "Sample: {'example_id': '00066667', 'category': 'bit_manipulation', 'prompt': \"In Alice's Wonderland, a secret bit manipulation rule transforms 8-bit binary numbers. The transformation involves operations like bit shifts, rotations, XOR, AND, OR, NOT, and possibly majority or choice functions.\\n\\nHere are some examples of input -> output:\\n01010001 -> 11011101\\n00001001 -> 01101101\\n00010101 -> 01010101\\n11111111 -> 10000001\\n10011101 -> 01000101\\n00111011 -> 00001001\\n10111101 -> 00000101\\n00100110 -> 10110011\\n\\nNow, determine the output for: 00110100\", 'gold': '10010111', 'source': 'kaggle-official', 'split': 'train', 'dataset_version': 'kaggle-v1', 'metadata': {}}\n"
+     ]
+    }
+   ],
+   "source": [
+    "import json\n",
+    "\n",
+    "DATASET_VERSION = \"kaggle-v1\"\n",
+    "OUT_DIR = REPO_ROOT / \"data\" / \"eval\"\n",
+    "OUT_DIR.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "records = []\n",
+    "for _, row in df.iterrows():\n",
+    "    records.append({\n",
+    "        \"example_id\": str(row[\"id\"]),\n",
+    "        \"category\": row[\"category\"],\n",
+    "        \"prompt\": row[\"prompt\"],\n",
+    "        \"gold\": str(row[\"answer\"]),\n",
+    "        \"source\": \"kaggle-official\",\n",
+    "        \"split\": \"train\",\n",
+    "        \"dataset_version\": DATASET_VERSION,\n",
+    "        \"metadata\": {}\n",
+    "    })\n",
+    "\n",
+    "out_path = OUT_DIR / \"train_normalized.jsonl\"\n",
+    "with open(out_path, \"w\") as f:\n",
+    "    for rec in records:\n",
+    "        f.write(json.dumps(rec) + \"\\n\")\n",
+    "\n",
+    "print(f\"Wrote {len(records)} rows → data/eval/train_normalized.jsonl\")\n",
+    "print(f\"Sample: {records[0]}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "risks",
+   "metadata": {},
+   "source": [
+    "## Results / Open Risks\n",
+    "\n",
+    "- Dataset loaded from Kaggle official source (`kaggle-v1`): 9,500 rows, 3 columns (`id`, `prompt`, `answer`).\n",
+    "- 6 categories parsed from prompt text (no `category` column in raw data): `bit_manipulation`, `text_cipher`, `numeral_system`, `unit_conversion`, `physics_gravity`, `equation_symbolic`.\n",
+    "- Category distribution is even (~1,550–1,600 rows each). No missing values.\n",
+    "- Gold answers are plain strings — no `\\boxed{}` in training data. The evaluator wraps model output in `\\boxed{}` and strips it before exact-match comparison.\n",
+    "- Prompt lengths: mean 301 chars, max 510. Answer lengths: mean 8 chars, max 39.\n",
+    "- Wrote `data/eval/train_normalized.jsonl` (9,500 rows, git-ignored). Input for notebook 03.\n",
+    "- Risk: category parsing uses keyword matching on prompt text — if competition adds new category types, `extract_category()` will return `unknown` and need updating."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sources",
+   "metadata": {},
+   "source": [
+    "## Sources\n",
+    "\n",
+    "- [Competition facts doc](../docs/architecture/COMPETITION.md)\n",
+    "- [Architecture doc](../docs/architecture/ARCHITECTURE.md)\n",
+    "- [Kaggle competition data](https://www.kaggle.com/competitions/nvidia-nemotron-model-reasoning-challenge/data)\n",
+    "- [src/contracts.py](../src/contracts.py)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
 }

--- a/notebooks/03_validation_and_golden_set.ipynb
+++ b/notebooks/03_validation_and_golden_set.ipynb
@@ -1,139 +1,411 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "id": "overview",
-      "metadata": {},
-      "source": [
-        "# 03. Validation and Golden Set Design\n",
-        "\n",
-        "- Parent issue: `#18`\n",
-        "- Status: `scaffolded`\n",
-        "- Summary: Define how the team will hold out validation data and protect against regressions.\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "audience",
-      "metadata": {},
-      "source": [
-        "## Audience and Why It Matters\n",
-        "\n",
-        "Anyone evaluating results or reviewing training claims.\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "decision",
-      "metadata": {},
-      "source": [
-        "## Decision / Hypothesis\n",
-        "\n",
-        "Reserve a stratified validation split and a smaller golden regression set before any serious training work starts.\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "environment",
-      "metadata": {},
-      "source": [
-        "## Environment and Reproduction\n",
-        "\n",
-        "            This notebook is scaffolded to execute cleanly before the implementation code exists.\n",
-        "\n",
-        "- Python: 3.11+\n",
-        "- Run from repo root or open directly in Jupyter\n",
-        "- Expected companion issue and registry entry: `docs/execution/NOTEBOOKS.md`\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "environment-check",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "from pathlib import Path\n",
-        "import platform\n",
-        "\n",
-        "REPO_ROOT = Path.cwd()\n",
-        "\n",
-        "print(f\"Repo root: {REPO_ROOT}\")\n",
-        "print(f\"Python platform: {platform.platform()}\")\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "method",
-      "metadata": {},
-      "source": [
-        "## Method and Outputs\n",
-        "\n",
-        "            ### Planned method\n",
-        "            - Document the validation split policy and category coverage expectations.\n",
-        "- Describe the golden-set role in catching regressions that aggregate metrics can hide.\n",
-        "- Tie these choices back to the plan review findings.\n",
-        "\n",
-        "            ### Expected outputs\n",
-        "            - Validation split policy\n",
-        "- Golden-set checklist\n",
-        "- Measurement caveats for small category slices\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "task-list",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "planned_tasks = [\n",
-        "    \"replace scaffold text with verified findings\",\n",
-        "    \"link concrete artifacts produced during execution\",\n",
-        "    \"update docs/execution/NOTEBOOKS.md when status changes\",\n",
-        "]\n",
-        "\n",
-        "for item in planned_tasks:\n",
-        "    print(f\"- {item}\")\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "risks",
-      "metadata": {},
-      "source": [
-        "## Results / Open Risks\n",
-        "\n",
-        "            This scaffold intentionally records the current open questions before implementation code exists.\n",
-        "\n",
-        "            - If the hold-out split is too small, improvements may be noise.\n",
-        "- If the golden set is poorly chosen, it may fail to catch real regressions.\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "sources",
-      "metadata": {},
-      "source": [
-        "## Sources\n",
-        "\n",
-        "            - [Execution plan v0.2](docs/planning/plan_v0.2.md)\n",
-        "- [Plan review](docs/planning/plan_review.md)\n",
-        "- [Architecture doc](docs/architecture/ARCHITECTURE.md)\n"
-      ]
-    }
-  ],
-  "metadata": {
-    "kernelspec": {
-      "display_name": "Python 3",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "name": "python",
-      "version": "3.11"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "overview",
+   "metadata": {},
+   "source": [
+    "# 03. Validation and Golden Set Design\n",
+    "\n",
+    "- Parent issue: `#18`\n",
+    "- Status: `active`\n",
+    "- Summary: Define how the team will hold out validation data and protect against regressions.\n"
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 5
+  {
+   "cell_type": "markdown",
+   "id": "audience",
+   "metadata": {},
+   "source": [
+    "## Audience and Why It Matters\n",
+    "\n",
+    "Anyone evaluating results or reviewing training claims.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "decision",
+   "metadata": {},
+   "source": [
+    "## Decision / Hypothesis\n",
+    "\n",
+    "Reserve a stratified validation split and a smaller golden regression set before any serious training work starts.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "environment",
+   "metadata": {},
+   "source": [
+    "## Environment and Reproduction\n",
+    "\n",
+    "- Python: 3.7.9 (tested); 3.11+ recommended for full src/ compatibility\n",
+    "- Run from repo root: `jupyter notebook` from `CS4650-Nvidia-Nemotron-Challenge/`\n",
+    "- Notebook uses `Path.cwd().parent` to resolve repo root when launched from `notebooks/`\n",
+    "- Input: `data/eval/train_normalized.jsonl` (produced by notebook 02)\n",
+    "- Outputs: `data/eval/validation_200.jsonl`, `data/eval/golden_20.jsonl`, `data/eval/splits_manifest.json` (all git-ignored)\n",
+    "- Companion issue and registry entry: `docs/execution/NOTEBOOKS.md`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "environment-check",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Repo root : C:\\Users\\SBaroni\\CS4650-Nvidia-Nemotron-Challenge\n",
+      "Python    : 3.7.9\n",
+      "Platform  : Windows-10-10.0.26100-SP0\n",
+      "Seed      : 42\n"
+     ]
+    }
+   ],
+   "source": [
+    "import sys, json, random, platform\n",
+    "from pathlib import Path\n",
+    "\n",
+    "_cwd = Path.cwd()\n",
+    "REPO_ROOT = _cwd.parent\n",
+    "if str(REPO_ROOT) not in sys.path:\n",
+    "    sys.path.insert(0, str(REPO_ROOT))\n",
+    "\n",
+    "SEED = 42\n",
+    "random.seed(SEED)\n",
+    "\n",
+    "print(f\"Repo root : {REPO_ROOT}\")\n",
+    "print(f\"Python    : {sys.version.split()[0]}\")\n",
+    "print(f\"Platform  : {platform.platform()}\")\n",
+    "print(f\"Seed      : {SEED}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "method",
+   "metadata": {},
+   "source": [
+    "## Method and Outputs\n",
+    "\n",
+    "            ### Planned method\n",
+    "            - Document the validation split policy and category coverage expectations.\n",
+    "- Describe the golden-set role in catching regressions that aggregate metrics can hide.\n",
+    "- Tie these choices back to the plan review findings.\n",
+    "\n",
+    "            ### Expected outputs\n",
+    "            - Validation split policy\n",
+    "- Golden-set checklist\n",
+    "- Measurement caveats for small category slices\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "task-list",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Loaded 9500 records from train_normalized.jsonl\n",
+      "Sample: {'example_id': '00066667', 'category': 'bit_manipulation', 'prompt': \"In Alice's Wonderland, a secret bit manipulation rule transforms 8-bit binary numbers. The transformation involves operations like bit shifts, rotations, XOR, AND, OR, NOT, and possibly majority or choice functions.\\n\\nHere are some examples of input -> output:\\n01010001 -> 11011101\\n00001001 -> 01101101\\n00010101 -> 01010101\\n11111111 -> 10000001\\n10011101 -> 01000101\\n00111011 -> 00001001\\n10111101 -> 00000101\\n00100110 -> 10110011\\n\\nNow, determine the output for: 00110100\", 'gold': '10010111', 'source': 'kaggle-official', 'split': 'train', 'dataset_version': 'kaggle-v1', 'metadata': {}}\n"
+     ]
+    }
+   ],
+   "source": [
+    "IN_PATH = REPO_ROOT / \"data\" / \"eval\" / \"train_normalized.jsonl\"\n",
+    "\n",
+    "records = []\n",
+    "with open(IN_PATH) as f:\n",
+    "    for line in f:\n",
+    "        records.append(json.loads(line))\n",
+    "\n",
+    "print(f\"Loaded {len(records)} records from train_normalized.jsonl\")\n",
+    "print(f\"Sample: {records[0]}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "481c4291",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Categories: ['bit_manipulation', 'equation_symbolic', 'numeral_system', 'physics_gravity', 'text_cipher', 'unit_conversion']\n",
+      "\n",
+      "Validation split: 200 rows\n",
+      "  bit_manipulation         : 34\n",
+      "  equation_symbolic        : 34\n",
+      "  numeral_system           : 33\n",
+      "  physics_gravity          : 33\n",
+      "  text_cipher              : 33\n",
+      "  unit_conversion          : 33\n"
+     ]
+    }
+   ],
+   "source": [
+    "from collections import defaultdict\n",
+    "\n",
+    "# Group records by category\n",
+    "by_category = defaultdict(list)\n",
+    "for rec in records:\n",
+    "    by_category[rec[\"category\"]].append(rec)\n",
+    "\n",
+    "categories = sorted(by_category.keys())\n",
+    "print(f\"Categories: {categories}\")\n",
+    "\n",
+    "# Sample evenly: 200 rows / 6 categories = ~33 per category\n",
+    "N_VAL = 200\n",
+    "per_category = N_VAL // len(categories)  # 33\n",
+    "remainder = N_VAL % len(categories)       # 2 leftover\n",
+    "\n",
+    "val_rows = []\n",
+    "for i, cat in enumerate(categories):\n",
+    "    pool = by_category[cat].copy()\n",
+    "    random.shuffle(pool)\n",
+    "    # give 1 extra row to the first `remainder` categories\n",
+    "    n = per_category + (1 if i < remainder else 0)\n",
+    "    val_rows.extend(pool[:n])\n",
+    "\n",
+    "# Shuffle the final val set\n",
+    "random.shuffle(val_rows)\n",
+    "\n",
+    "print(f\"\\nValidation split: {len(val_rows)} rows\")\n",
+    "for cat in categories:\n",
+    "    count = sum(1 for r in val_rows if r[\"category\"] == cat)\n",
+    "    print(f\"  {cat:<25}: {count}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "8c7ee36f",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Wrote 200 rows → data/eval/validation_200.jsonl\n"
+     ]
+    }
+   ],
+   "source": [
+    "VAL_PATH = REPO_ROOT / \"data\" / \"eval\" / \"validation_200.jsonl\"\n",
+    "\n",
+    "with open(VAL_PATH, \"w\") as f:\n",
+    "    for rec in val_rows:\n",
+    "        f.write(json.dumps(rec) + \"\\n\")\n",
+    "\n",
+    "print(f\"Wrote {len(val_rows)} rows → data/eval/validation_200.jsonl\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "da048071",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Golden set: 20 rows\n",
+      "  bit_manipulation         : 4\n",
+      "  equation_symbolic        : 4\n",
+      "  numeral_system           : 3\n",
+      "  physics_gravity          : 3\n",
+      "  text_cipher              : 3\n",
+      "  unit_conversion          : 3\n",
+      "\n",
+      "Overlap with val set: 0 (should be 0)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Get the example_ids already used in val so we don't overlap\n",
+    "val_ids = {r[\"example_id\"] for r in val_rows}\n",
+    "\n",
+    "# Sample from the remaining rows (not in val)\n",
+    "remaining = defaultdict(list)\n",
+    "for rec in records:\n",
+    "    if rec[\"example_id\"] not in val_ids:\n",
+    "        remaining[rec[\"category\"]].append(rec)\n",
+    "\n",
+    "N_GOLDEN = 20\n",
+    "per_cat_golden = N_GOLDEN // len(categories)   # 3\n",
+    "remainder_golden = N_GOLDEN % len(categories)  # 2 leftover\n",
+    "\n",
+    "golden_rows = []\n",
+    "for i, cat in enumerate(categories):\n",
+    "    pool = remaining[cat].copy()\n",
+    "    random.shuffle(pool)\n",
+    "    n = per_cat_golden + (1 if i < remainder_golden else 0)\n",
+    "    golden_rows.extend(pool[:n])\n",
+    "\n",
+    "print(f\"Golden set: {len(golden_rows)} rows\")\n",
+    "for cat in categories:\n",
+    "    count = sum(1 for r in golden_rows if r[\"category\"] == cat)\n",
+    "    print(f\"  {cat:<25}: {count}\")\n",
+    "\n",
+    "# Confirm no overlap with val\n",
+    "overlap = {r[\"example_id\"] for r in golden_rows} & val_ids\n",
+    "print(f\"\\nOverlap with val set: {len(overlap)} (should be 0)\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "b5bda59c",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Wrote 20 rows → data/eval/golden_20.jsonl\n",
+      "WARNING: golden_20.jsonl is now frozen. Do not edit in place.\n",
+      "If changes are needed, create golden_40.jsonl instead.\n"
+     ]
+    }
+   ],
+   "source": [
+    "GOLDEN_PATH = REPO_ROOT / \"data\" / \"eval\" / \"golden_20.jsonl\"\n",
+    "\n",
+    "with open(GOLDEN_PATH, \"w\") as f:\n",
+    "    for rec in golden_rows:\n",
+    "        f.write(json.dumps(rec) + \"\\n\")\n",
+    "\n",
+    "print(f\"Wrote {len(golden_rows)} rows → data/eval/golden_20.jsonl\")\n",
+    "print(\"WARNING: golden_20.jsonl is now frozen. Do not edit in place.\")\n",
+    "print(\"If changes are needed, create golden_40.jsonl instead.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "9b773c2d",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Manifest:\n",
+      "{\n",
+      "  \"created_at\": \"2026-05-01T21:49:37.347338Z\",\n",
+      "  \"dataset_version\": \"kaggle-v1\",\n",
+      "  \"seed\": 42,\n",
+      "  \"source\": \"data/eval/train_normalized.jsonl\",\n",
+      "  \"validation\": {\n",
+      "    \"filename\": \"validation_200.jsonl\",\n",
+      "    \"n_rows\": 200,\n",
+      "    \"per_category\": {\n",
+      "      \"bit_manipulation\": 34,\n",
+      "      \"equation_symbolic\": 34,\n",
+      "      \"numeral_system\": 33,\n",
+      "      \"physics_gravity\": 33,\n",
+      "      \"text_cipher\": 33,\n",
+      "      \"unit_conversion\": 33\n",
+      "    }\n",
+      "  },\n",
+      "  \"golden\": {\n",
+      "    \"filename\": \"golden_20.jsonl\",\n",
+      "    \"n_rows\": 20,\n",
+      "    \"per_category\": {\n",
+      "      \"bit_manipulation\": 4,\n",
+      "      \"equation_symbolic\": 4,\n",
+      "      \"numeral_system\": 3,\n",
+      "      \"physics_gravity\": 3,\n",
+      "      \"text_cipher\": 3,\n",
+      "      \"unit_conversion\": 3\n",
+      "    }\n",
+      "  }\n",
+      "}\n"
+     ]
+    }
+   ],
+   "source": [
+    "import datetime\n",
+    "\n",
+    "manifest = {\n",
+    "    \"created_at\": datetime.datetime.utcnow().isoformat() + \"Z\",\n",
+    "    \"dataset_version\": \"kaggle-v1\",\n",
+    "    \"seed\": SEED,\n",
+    "    \"source\": \"data/eval/train_normalized.jsonl\",\n",
+    "    \"validation\": {\n",
+    "        \"filename\": \"validation_200.jsonl\",\n",
+    "        \"n_rows\": len(val_rows),\n",
+    "        \"per_category\": {cat: sum(1 for r in val_rows if r[\"category\"] == cat) for cat in categories}\n",
+    "    },\n",
+    "    \"golden\": {\n",
+    "        \"filename\": \"golden_20.jsonl\",\n",
+    "        \"n_rows\": len(golden_rows),\n",
+    "        \"per_category\": {cat: sum(1 for r in golden_rows if r[\"category\"] == cat) for cat in categories}\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "MANIFEST_PATH = REPO_ROOT / \"data\" / \"eval\" / \"splits_manifest.json\"\n",
+    "with open(MANIFEST_PATH, \"w\") as f:\n",
+    "    json.dump(manifest, f, indent=2)\n",
+    "\n",
+    "print(\"Manifest:\")\n",
+    "print(json.dumps(manifest, indent=2))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "risks",
+   "metadata": {},
+   "source": [
+    "## Results / Open Risks\n",
+    "\n",
+    "- Produced `validation_200.jsonl`: 200 rows, stratified across 6 categories (~33 per category), seed=42.\n",
+    "- Produced `golden_20.jsonl`: 20 rows, ~3-4 per category, no overlap with val set, seed=42.\n",
+    "- Manifest written to `data/eval/splits_manifest.json` recording provenance.\n",
+    "- Risk: 33 rows per category is a small sample — accuracy scores on individual categories will have high variance. Use overall accuracy as the primary metric.\n",
+    "- Risk: golden_20.jsonl is now frozen. Any future changes require a new versioned filename."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sources",
+   "metadata": {},
+   "source": [
+    "## Sources\n",
+    "\n",
+    "- [Execution plan v0.2](../docs/planning/plan_v0.2.md)\n",
+    "- [Architecture doc](../docs/architecture/ARCHITECTURE.md)\n",
+    "- [data/eval/README.md](../data/eval/README.md)\n",
+    "- [notebooks/02_dataset_schema_and_eda.ipynb](02_dataset_schema_and_eda.ipynb)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
 }


### PR DESCRIPTION
Implements #17 and #18.

## What this does
- Loads official Kaggle training data (9,500 rows) and runs EDA
- Parses 6 categories from prompt text (no category column in raw data)
- Normalizes all rows to ReasoningExample-compatible JSONL
- Produces validation_200.jsonl (200 rows, stratified, seed=42)
- Produces golden_20.jsonl (20 rows, ~3-4 per category, zero overlap with val, seed=42)
- Writes splits_manifest.json with full provenance

## Key findings for the team
- Columns: id, prompt, answer (no category column — parsed via keyword matching)
- 9,500 rows, 6 categories, ~1,550–1,600 per category, no missing values
- Gold answers are plain strings — no \boxed{} in training data
- Prompt lengths: mean 301 chars, max 510. Answer lengths: mean 8 chars, max 39.

## Unblocks
- Notebook 04 (baseline eval)
- Notebook 05 (prompt sweeps)