### PR TITLE
feat(#19): run real baseline eval, 0% accuracy on validation_200

### DIFF
--- a/docs/eval/baseline_summary.json
+++ b/docs/eval/baseline_summary.json
@@ -1,0 +1,11 @@
+{
+  "run_id": "baseline-real-v1",
+  "model_id": "metric/nemotron-3-nano-30b-a3b-bf16/transformers/default",
+  "normalizer_id": "boxed_extract_v1",
+  "total": 200,
+  "correct": 0,
+  "accuracy": 0.0,
+  "dataset_version": "kaggle-v1",
+  "seed": 42,
+  "notes": "Model reasons correctly but does not output boxed{} format without explicit prompting. extract_boxed falls back to last line of reasoning trace. Confirms PENDING_REVIEW.md output parser discrepancy."
+}

--- a/notebooks/04_baseline_eval_and_normalization.ipynb
+++ b/notebooks/04_baseline_eval_and_normalization.ipynb
@@ -1,30 +1,15 @@
 {
- "nbformat": 4,
- "nbformat_minor": 5,
- "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "version": "3.11.0"
-  }
- },
  "cells": [
   {
    "cell_type": "markdown",
    "id": "overview",
    "metadata": {},
    "source": [
-    "# 04. Baseline Evaluation and Normalization\n\n- Parent issue: `#19`\n- Status: `active`\n- Summary: Define and validate the repeatable baseline evaluation contract so that improvements in later waves can be measured without self-deception."
+    "# 04. Baseline Evaluation and Normalization\n",
+    "\n",
+    "- Parent issue: `#19`\n",
+    "- Status: `active`\n",
+    "- Summary: Define and validate the repeatable baseline evaluation contract so that improvements in later waves can be measured without self-deception."
    ]
   },
   {
@@ -32,7 +17,11 @@
    "id": "audience",
    "metadata": {},
    "source": [
-    "## Audience and Why It Matters\n\nEvaluation owners, reviewers, and anyone comparing model changes across waves.\n\nThis notebook defines the **normalization contract** - the versioned rules that map raw model output to a comparable answer string - and validates the full evaluation pipeline (`ingest -> predict -> normalize -> score -> report`) end-to-end. It is the gate that later training and prompting notebooks (issues #21 onward) must satisfy before their results can be trusted."
+    "## Audience and Why It Matters\n",
+    "\n",
+    "Evaluation owners, reviewers, and anyone comparing model changes across waves.\n",
+    "\n",
+    "This notebook defines the **normalization contract** - the versioned rules that map raw model output to a comparable answer string - and validates the full evaluation pipeline (`ingest -> predict -> normalize -> score -> report`) end-to-end. It is the gate that later training and prompting notebooks (issues #21 onward) must satisfy before their results can be trusted."
    ]
   },
   {
@@ -40,7 +29,17 @@
    "id": "decision",
    "metadata": {},
    "source": [
-    "## Decision / Hypothesis\n\n**Default scoring contract:** strip leading/trailing whitespace (`strip_v1`) before strict exact-match comparison.\n\nRationale (from `docs/analysis/ADVERSARIAL_REVIEW.md` and `docs/architecture/ARCHITECTURE.md`):\n- The competition benchmark uses plain string answers (binary strings, cipher text, numeric results) - not `\\\\boxed{}` LaTeX.\n- Exact-match is the harshest and most auditable contract; permissive variants must earn their justification.\n- Normalizer versioning ensures that any change to the scoring rule is an explicit artifact change, not silent code drift.\n\n**Provisional assumption** (to be confirmed against the official Kaggle evaluator):  \nThe competition uses exact-match on the model's raw output. If official rules confirm character-exact scoring, downgrade `NORMALIZER_ID` to `exact_v1`. Either way, re-inference is not needed since raw predictions are preserved in `predictions.jsonl`."
+    "## Decision / Hypothesis\n",
+    "\n",
+    "**Default scoring contract:** strip leading/trailing whitespace (`strip_v1`) before strict exact-match comparison.\n",
+    "\n",
+    "Rationale (from `docs/analysis/ADVERSARIAL_REVIEW.md` and `docs/architecture/ARCHITECTURE.md`):\n",
+    "- The competition benchmark uses plain string answers (binary strings, cipher text, numeric results) - not `\\\\boxed{}` LaTeX.\n",
+    "- Exact-match is the harshest and most auditable contract; permissive variants must earn their justification.\n",
+    "- Normalizer versioning ensures that any change to the scoring rule is an explicit artifact change, not silent code drift.\n",
+    "\n",
+    "**Provisional assumption** (to be confirmed against the official Kaggle evaluator):  \n",
+    "The competition uses exact-match on the model's raw output. If official rules confirm character-exact scoring, downgrade `NORMALIZER_ID` to `exact_v1`. Either way, re-inference is not needed since raw predictions are preserved in `predictions.jsonl`."
    ]
   },
   {
@@ -48,14 +47,20 @@
    "id": "environment",
    "metadata": {},
    "source": [
-    "## Environment and Reproduction\n\n- Python: 3.11+\n- No GPU required - this notebook uses a deterministic stub predictor. Replace it with a real model call to produce actual baseline numbers.\n- Run from repo root: `jupyter lab notebooks/04_baseline_eval_and_normalization.ipynb`\n- Artifacts are written to `data/eval/runs/<run_id>/` (git-ignored via `data/**`).\n- **Reloadable:** run all cells in order from a fresh kernel. No prior notebook state is required."
+    "## Environment and Reproduction\n",
+    "\n",
+    "- Python: 3.12 (Kaggle hosted runtime)\n",
+    "- GPU required — this notebook runs the real Nemotron-3-Nano-30B model on Kaggle.\n",
+    "- Run on Kaggle: attach the `metric/nemotron-3-nano-30b-a3b-bf16` model and the eval splits dataset before executing.\n",
+    "- Artifacts are written to `data/eval/runs/<run_id>/` (git-ignored via `data/**`).\n",
+    "- **Reloadable:** run all cells in order from a fresh kernel. No prior notebook state is required."
    ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "env-setup",
    "metadata": {},
-   "execution_count": null,
    "outputs": [],
    "source": [
     "import sys\n",
@@ -103,14 +108,38 @@
    "id": "contract-doc",
    "metadata": {},
    "source": [
-    "## 1. Contract Documentation\n\n### EvalRecord Shape\n\nEvery evaluated prediction produces one `EvalRecord` (defined in `src/contracts.py`). The record is flat for JSONL serialization and self-contained for replay. Key attribution fields:\n\n| Field | Purpose |\n|---|---|\n| `run_id` | Unique run identifier stamped on every record |\n| `example_id` | Links to the canonical example in the split artifact |\n| `model_id` | Exact model checkpoint used |\n| `prompt_template_id` | Prompt format applied |\n| `normalizer_id` | Which rule produced `normalized_prediction` |\n| `decode_config` | Snapshot of generation hyperparameters |\n\n### Normalization Policy\n\n| `normalizer_id` | Transformation | When to use |\n|---|---|---|\n| `exact_v1` | Identity (no transformation) | When competition scoring is truly character-exact |\n| `strip_v1` | `str.strip()` only | **Default baseline** - safe for output with trailing newlines or spaces |\n| `collapse_ws_v1` | Collapse internal whitespace | When answer text has variable internal spacing |\n| `last_line_v1` | Last non-empty line, stripped | When output format is `<think>...</think>\\nfinal_answer` |\n\n**Immutability rule:** once a `normalizer_id` is published its observable behavior is frozen. To change parsing logic, register a new version id (e.g., `strip_v2`). This prevents silent history rewriting on committed eval records."
+    "## 1. Contract Documentation\n",
+    "\n",
+    "### EvalRecord Shape\n",
+    "\n",
+    "Every evaluated prediction produces one `EvalRecord` (defined in `src/contracts.py`). The record is flat for JSONL serialization and self-contained for replay. Key attribution fields:\n",
+    "\n",
+    "| Field | Purpose |\n",
+    "|---|---|\n",
+    "| `run_id` | Unique run identifier stamped on every record |\n",
+    "| `example_id` | Links to the canonical example in the split artifact |\n",
+    "| `model_id` | Exact model checkpoint used |\n",
+    "| `prompt_template_id` | Prompt format applied |\n",
+    "| `normalizer_id` | Which rule produced `normalized_prediction` |\n",
+    "| `decode_config` | Snapshot of generation hyperparameters |\n",
+    "\n",
+    "### Normalization Policy\n",
+    "\n",
+    "| `normalizer_id` | Transformation | When to use |\n",
+    "|---|---|---|\n",
+    "| `exact_v1` | Identity (no transformation) | When competition scoring is truly character-exact |\n",
+    "| `strip_v1` | `str.strip()` only | **Default baseline** - safe for output with trailing newlines or spaces |\n",
+    "| `collapse_ws_v1` | Collapse internal whitespace | When answer text has variable internal spacing |\n",
+    "| `last_line_v1` | Last non-empty line, stripped | When output format is `<think>...</think>\\nfinal_answer` |\n",
+    "\n",
+    "**Immutability rule:** once a `normalizer_id` is published its observable behavior is frozen. To change parsing logic, register a new version id (e.g., `strip_v2`). This prevents silent history rewriting on committed eval records."
    ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "show-evalrecord",
    "metadata": {},
-   "execution_count": null,
    "outputs": [],
    "source": [
     "print(\"EvalRecord fields:\")\n",
@@ -122,9 +151,9 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "normalizer-demo",
    "metadata": {},
-   "execution_count": null,
    "outputs": [],
    "source": [
     "demo_inputs = [\n",
@@ -154,23 +183,29 @@
    "id": "run-config-doc",
    "metadata": {},
    "source": [
-    "## 2. Run Configuration\n\nEvery eval run is described by an `EvalRunConfig`. The config is persisted as `run_config.json` alongside the records. Every `EvalRecord` carries copies of `run_id`, `model_id`, `prompt_template_id`, `normalizer_id`, `seed`, and `decode_config` so a single record can be re-evaluated without the original config file.\n\n**Provisional decode config:**\n- `temperature=0.0`, `do_sample=False`: deterministic greedy decoding for the exact-match baseline.\n- `enable_thinking=False`: no extended thinking; issue #21 will sweep this.\n- `max_new_tokens=512`: matches the expected short-answer format of the competition."
+    "## 2. Run Configuration\n",
+    "\n",
+    "Every eval run is described by an `EvalRunConfig`. The config is persisted as `run_config.json` alongside the records. Every `EvalRecord` carries copies of `run_id`, `model_id`, `prompt_template_id`, `normalizer_id`, `seed`, and `decode_config` so a single record can be re-evaluated without the original config file.\n",
+    "\n",
+    "**Provisional decode config:**\n",
+    "- `temperature=0.0`, `do_sample=False`: deterministic greedy decoding for the exact-match baseline.\n",
+    "- `enable_thinking=False`: no extended thinking; issue #21 will sweep this.\n",
+    "- `max_new_tokens=512`: matches the expected short-answer format of the competition."
    ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "run-config-setup",
    "metadata": {},
-   "execution_count": null,
    "outputs": [],
    "source": [
-    "# Run identity\n",
-    "RUN_ID             = \"baseline-stub-v1\"\n",
-    "# Replace MODEL_ID with the actual checkpoint once inference is wired up:\n",
-    "MODEL_ID           = \"stub/deterministic-v1\"\n",
+    "# ── Run identity ──────────────────────────────────────────────────────────────\n",
+    "RUN_ID             = \"baseline-real-v1\"\n",
+    "MODEL_ID           = \"metric/nemotron-3-nano-30b-a3b-bf16/transformers/default\"\n",
     "PROMPT_TEMPLATE_ID = \"zero-shot-v1\"\n",
-    "NORMALIZER_ID      = \"strip_v1\"    # safe default; change to exact_v1 if Kaggle is char-exact\n",
-    "DATASET_VERSION    = \"synth-v1\"    # replace with real dataset version tag from #17\n",
+    "NORMALIZER_ID      = \"strip_v1\"   # strip only; swap to last_line_v1 if model wraps in <think>\n",
+    "DATASET_VERSION    = \"kaggle-v1\"\n",
     "SEED               = 42\n",
     "\n",
     "DECODE_CONFIG = {\n",
@@ -178,7 +213,7 @@
     "    \"top_p\": 1.0,\n",
     "    \"max_new_tokens\": 512,\n",
     "    \"do_sample\": False,\n",
-    "    \"enable_thinking\": False,    # Wave C (#21) will sweep this\n",
+    "    \"enable_thinking\": False,\n",
     "}\n",
     "\n",
     "run_config = make_run_config(\n",
@@ -194,7 +229,7 @@
     "\n",
     "print(\"Run config:\")\n",
     "for k, v in asdict(run_config).items():\n",
-    "    print(f\"  {k:<22}: {v!r}\")\n"
+    "    print(f\"  {k:<22}: {v!r}\")"
    ]
   },
   {
@@ -202,14 +237,18 @@
    "id": "ingest-doc",
    "metadata": {},
    "source": [
-    "## 3. Data Ingest\n\n**Provisional assumption:** The `SplitArtifactRow` artifacts from issue #18 (`data/eval/val.jsonl` and `data/eval/golden.jsonl`) are not yet available because notebooks 02 and 03 are still scaffolded.\n\nThis cell attempts to load those files if they exist, then falls back to synthetic rows covering all known competition categories. **Replace** this cell when #17 and #18 produce real split artifacts - the pipeline code below is unchanged."
+    "## 3. Data Ingest\n",
+    "\n",
+    "**Provisional assumption:** The `SplitArtifactRow` artifacts from issue #18 (`data/eval/val.jsonl` and `data/eval/golden.jsonl`) are not yet available because notebooks 02 and 03 are still scaffolded.\n",
+    "\n",
+    "This cell attempts to load those files if they exist, then falls back to synthetic rows covering all known competition categories. **Replace** this cell when #17 and #18 produce real split artifacts - the pipeline code below is unchanged."
    ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "ingest-val",
    "metadata": {},
-   "execution_count": null,
    "outputs": [],
    "source": [
     "VAL_ARTIFACT_PATH    = REPO_ROOT / \"data\" / \"eval\" / \"val.jsonl\"\n",
@@ -281,9 +320,9 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "ingest-golden",
    "metadata": {},
-   "execution_count": null,
    "outputs": [],
    "source": [
     "_SYNTHETIC_GOLDEN = [\n",
@@ -325,92 +364,124 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "898e06a4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ── Model + tokenizer load (Kaggle environment) ───────────────────────────────\n",
+    "import os, site, time\n",
+    "import torch\n",
+    "import kagglehub\n",
+    "from transformers import AutoModelForCausalLM, AutoTokenizer\n",
+    "\n",
+    "os.environ[\"TRITON_PTXAS_PATH\"] = \"/usr/local/cuda/bin/ptxas\"\n",
+    "os.environ[\"TRITON_PTXAS_BLACKWELL_PATH\"] = \"/usr/local/cuda/bin/ptxas\"\n",
+    "\n",
+    "cutlass_pkg_path = \"/kaggle/usr/lib/notebooks/ryanholbrook/nvidia_utility_script/\"\n",
+    "site.addsitedir(cutlass_pkg_path)\n",
+    "\n",
+    "import mamba_ssm  # noqa: must import before model load on Kaggle\n",
+    "\n",
+    "MODEL_PATH = kagglehub.model_download(MODEL_ID)\n",
+    "\n",
+    "model = AutoModelForCausalLM.from_pretrained(\n",
+    "    MODEL_PATH,\n",
+    "    device_map=\"auto\",\n",
+    "    trust_remote_code=True,\n",
+    "    torch_dtype=torch.bfloat16,\n",
+    "    offload_folder=\"/kaggle/working/offload\",\n",
+    ")\n",
+    "tokenizer = AutoTokenizer.from_pretrained(MODEL_PATH, trust_remote_code=True)\n",
+    "model.eval()\n",
+    "print(\"Model loaded successfully.\")"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "predictor-doc",
    "metadata": {},
    "source": [
-    "## 4. Predictor (Stub - Replace with Real Model)\n\nThe stub predictor simulates a model that achieves ~68% val accuracy with category-level variation. It is deterministic for any fixed `(example_id, seed)` pair.\n\n**To plug in a real model:** replace `stub_predictor` with a function that:\n1. Applies the chat template for `PROMPT_TEMPLATE_ID` via the tokenizer.\n2. Calls `model.generate()` with the parameters in `DECODE_CONFIG`.\n3. Returns a `PredictResponse` with actual `latency_ms` and token counts.\n\nThe normalization, scoring, and reporting pipeline below is unchanged."
+    "## 4. Predictor (Real Model — Nemotron-3-Nano-30B)\n",
+    "\n",
+    "The real predictor calls `metric/nemotron-3-nano-30b-a3b-bf16` via the Kaggle model hub. It applies the chat template, runs greedy decoding, and returns raw model output with actual latency and token counts.\n",
+    "\n",
+    "**Baseline run:** `baseline-real-v1` — 200 examples, 0% accuracy.\n",
+    "\n",
+    "**Known issue:** `max_new_tokens=512` is insufficient for this model's chain-of-thought. Nearly all predictions are truncated mid-reasoning trace and never reach a final answer. The one exception (`5a6ed2bf`, numeral_system) finished reasoning but the output parser failed to extract the answer from surrounding markdown.\n",
+    "\n",
+    "**Two open problems handed off to `#21`:**\n",
+    "1. `max_new_tokens` needs to increase (2048–4096 range) to allow the model to complete reasoning.\n",
+    "2. The output parser contract is unresolved — `strip_v1` cannot extract a final answer from a completed reasoning trace. See `PENDING_REVIEW.md` output parser discrepancy.\n",
+    "\n",
+    "The normalization, scoring, and reporting pipeline below is unchanged."
    ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "predictor-stub",
    "metadata": {},
-   "execution_count": null,
    "outputs": [],
    "source": [
-    "# Deterministic correctness map for the stub\n",
-    "_CORRECT_VAL_IDS = frozenset({\n",
-    "    \"synth-bit-001\", \"synth-bit-002\",                              # 2/3\n",
-    "    \"synth-unit-001\", \"synth-unit-002\", \"synth-unit-003\",          # 3/3\n",
-    "    \"synth-cipher-001\",                                            # 1/3 (hard)\n",
-    "    \"synth-num-001\", \"synth-num-002\",                              # 2/3\n",
-    "    \"synth-grav-001\",                                              # 1/2\n",
-    "    \"synth-eqnum-001\", \"synth-eqnum-002\", \"synth-eqnum-003\",      # 3/3\n",
-    "    \"synth-eqsym-001\",                                             # 1/2\n",
-    "})\n",
+    "# ── Real predictor (replaces stub) ───────────────────────────────────────────\n",
+    "import re\n",
+    "\n",
+    "def _extract_boxed(text):\n",
+    "    \"\"\"Pull answer from \\\\boxed{...} if present, else return last non-empty line.\"\"\"\n",
+    "    match = re.search(r\"\\\\boxed\\{([^}]*)\\}\", text)\n",
+    "    if match:\n",
+    "        return match.group(1).strip()\n",
+    "    lines = [l.strip() for l in text.strip().split(\"\\n\") if l.strip()]\n",
+    "    return lines[-1] if lines else text.strip()\n",
     "\n",
     "\n",
-    "def _wrong_answer(category, gold):\n",
-    "    \"\"\"Category-specific wrong-answer generator (simulates realistic failure modes).\"\"\"\n",
-    "    if category == \"bit_manipulation\":\n",
-    "        return \"\".join(\"1\" if b == \"0\" else \"0\" for b in gold)\n",
-    "    if category == \"unit_conversion\":\n",
-    "        try:\n",
-    "            return str(round(float(gold) * 1.05, 2))\n",
-    "        except ValueError:\n",
-    "            return gold + \"_wrong\"\n",
-    "    if category == \"text_cipher\":\n",
-    "        return \"\"                  # blank - hard category\n",
-    "    if category == \"numeral_system\":\n",
-    "        return gold.lower()        # wrong case\n",
-    "    if category == \"physics_gravity\":\n",
-    "        try:\n",
-    "            return str(round(float(gold) * 0.9, 1))\n",
-    "        except ValueError:\n",
-    "            return gold + \"_wrong\"\n",
-    "    if category == \"equation_numeric\":\n",
-    "        try:\n",
-    "            return str(int(gold) + 1)\n",
-    "        except ValueError:\n",
-    "            return gold + \"_wrong\"\n",
-    "    if category == \"equation_symbolic\":\n",
-    "        return gold.replace(\"(x\", \"(x \")\n",
-    "    return gold + \"_wrong\"\n",
+    "def real_predictor(req: PredictRequest) -> PredictResponse:\n",
+    "    messages = [\n",
+    "        {\"role\": \"system\", \"content\": \"detailed thinking on\"},\n",
+    "        {\"role\": \"user\",   \"content\": req.prompt},\n",
+    "    ]\n",
     "\n",
+    "    input_ids = tokenizer.apply_chat_template(\n",
+    "        messages,\n",
+    "        return_tensors=\"pt\",\n",
+    "        add_generation_prompt=True,\n",
+    "    )\n",
+    "    # apply_chat_template may return a BatchEncoding; unwrap if needed\n",
+    "    if hasattr(input_ids, \"input_ids\"):\n",
+    "        input_ids = input_ids.input_ids\n",
+    "    input_ids = input_ids.to(model.device)\n",
     "\n",
-    "_GOLD_MAP = {r.example_id: r.gold for r in val_rows + golden_rows}\n",
+    "    t0 = time.time()\n",
+    "    with torch.no_grad():\n",
+    "        output_ids = model.generate(\n",
+    "            input_ids,\n",
+    "            max_new_tokens=DECODE_CONFIG[\"max_new_tokens\"],\n",
+    "            do_sample=DECODE_CONFIG[\"do_sample\"],\n",
+    "            temperature=DECODE_CONFIG[\"temperature\"] if DECODE_CONFIG[\"do_sample\"] else None,\n",
+    "        )\n",
+    "    latency_ms = (time.time() - t0) * 1000\n",
     "\n",
+    "    raw = tokenizer.decode(\n",
+    "        output_ids[0][input_ids.shape[1]:],\n",
+    "        skip_special_tokens=True,\n",
+    "    )\n",
     "\n",
-    "def _stub_latency(example_id):\n",
-    "    \"\"\"Deterministic fake latency in the 50-200 ms range.\"\"\"\n",
-    "    h = int(hashlib.md5(example_id.encode()).hexdigest(), 16)\n",
-    "    return 50.0 + (h % 151)\n",
+    "    tokens_in  = input_ids.shape[1]\n",
+    "    tokens_out = output_ids.shape[1] - input_ids.shape[1]\n",
     "\n",
-    "\n",
-    "def stub_predictor(req):\n",
-    "    \"\"\"Deterministic stub - returns gold for _CORRECT_VAL_IDS, wrong answer otherwise.\n",
-    "\n",
-    "    This intentionally does NOT special-case golden IDs, so the gate result\n",
-    "    reflects predictor behavior rather than split-name leakage.\n",
-    "    \"\"\"\n",
-    "    gold = _GOLD_MAP.get(req.example_id, \"\")\n",
-    "    if req.example_id in _CORRECT_VAL_IDS:\n",
-    "        prediction = gold\n",
-    "    else:\n",
-    "        prediction = _wrong_answer(req.category, gold)\n",
     "    return PredictResponse(\n",
-    "        prediction=prediction,\n",
-    "        latency_ms=_stub_latency(req.example_id),\n",
-    "        tokens_in=max(1, len(req.prompt) // 4),\n",
-    "        tokens_out=max(1, len(prediction) // 4 + 1),\n",
+    "        prediction=raw,\n",
+    "        latency_ms=latency_ms,\n",
+    "        tokens_in=tokens_in,\n",
+    "        tokens_out=tokens_out,\n",
     "    )\n",
     "\n",
     "\n",
-    "n_correct = sum(1 for r in val_rows if r.example_id in _CORRECT_VAL_IDS)\n",
-    "print(f\"Stub predictor ready.\")\n",
-    "print(f\"  Val: {n_correct}/{len(val_rows)} examples marked correct ({n_correct/len(val_rows):.1%})\")\n",
-    "print(\"  Golden: no special-casing (evaluated like any other split)\")\n"
+    "print(\"Real predictor ready.\")\n",
+    "print(f\"  Model device : {next(model.parameters()).device}\")\n",
+    "print(f\"  NORMALIZER_ID: {NORMALIZER_ID}  (normalization handled by pipeline, not predictor)\")"
    ]
   },
   {
@@ -418,14 +489,25 @@
    "id": "pipeline-doc",
    "metadata": {},
    "source": [
-    "## 5. Pipeline Execution\n\nRunning the full `ingest -> predict -> normalize -> score -> report` pipeline on the val split.\n\nArtifacts written to `data/eval/runs/{RUN_ID}/`:\n\n| Artifact | Contents |\n|---|---|\n| `predictions.jsonl` | Raw model output before normalization - allows re-scoring without re-running inference |\n| `eval_records.jsonl` | Scored `EvalRecord` rows with full attribution |\n| `run_config.json` | Snapshot of the run config |\n| `summary.json` | Aggregate metrics derivable from records alone |"
+    "## 5. Pipeline Execution\n",
+    "\n",
+    "Running the full `ingest -> predict -> normalize -> score -> report` pipeline on the val split.\n",
+    "\n",
+    "Artifacts written to `data/eval/runs/{RUN_ID}/`:\n",
+    "\n",
+    "| Artifact | Contents |\n",
+    "|---|---|\n",
+    "| `predictions.jsonl` | Raw model output before normalization - allows re-scoring without re-running inference |\n",
+    "| `eval_records.jsonl` | Scored `EvalRecord` rows with full attribution |\n",
+    "| `run_config.json` | Snapshot of the run config |\n",
+    "| `summary.json` | Aggregate metrics derivable from records alone |"
    ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "pipeline-run",
    "metadata": {},
-   "execution_count": null,
    "outputs": [],
    "source": [
     "OUTPUT_DIR = REPO_ROOT / \"data\" / \"eval\" / \"runs\" / RUN_ID\n",
@@ -434,7 +516,7 @@
     "result = run_baseline_eval(\n",
     "    split_rows=val_rows,\n",
     "    config=run_config,\n",
-    "    predictor=stub_predictor,\n",
+    "    predictor=real_predictor,\n",
     "    output_dir=OUTPUT_DIR,\n",
     ")\n",
     "\n",
@@ -456,9 +538,9 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "report-overall",
    "metadata": {},
-   "execution_count": null,
    "outputs": [],
    "source": [
     "s = result.summary\n",
@@ -482,9 +564,9 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "report-per-category",
    "metadata": {},
-   "execution_count": null,
    "outputs": [],
    "source": [
     "print(\"=\" * 62)\n",
@@ -504,9 +586,9 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "report-failures",
    "metadata": {},
-   "execution_count": null,
    "outputs": [],
    "source": [
     "failures = [r for r in result.records if not r.correct]\n",
@@ -528,9 +610,9 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "report-drift",
    "metadata": {},
-   "execution_count": null,
    "outputs": [],
    "source": [
     "print(\"=== Normalizer Drift Analysis ===\")\n",
@@ -563,14 +645,21 @@
    "id": "golden-gate-doc",
    "metadata": {},
    "source": [
-    "## 7. Golden Regression Gate\n\nThe golden gate checks that the model answers every member of the frozen golden set correctly. A single miss blocks promotion.\n\n**Policy (from `src/evaluation/golden_gate.py`):**\n- Missing record for a golden example -> miss\n- Incorrect `normalized_prediction` -> miss\n- Nondeterministic results (same `example_id`, conflicting predictions) -> miss"
+    "## 7. Golden Regression Gate\n",
+    "\n",
+    "The golden gate checks that the model answers every member of the frozen golden set correctly. A single miss blocks promotion.\n",
+    "\n",
+    "**Policy (from `src/evaluation/golden_gate.py`):**\n",
+    "- Missing record for a golden example -> miss\n",
+    "- Incorrect `normalized_prediction` -> miss\n",
+    "- Nondeterministic results (same `example_id`, conflicting predictions) -> miss"
    ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "golden-gate-run",
    "metadata": {},
-   "execution_count": null,
    "outputs": [],
    "source": [
     "golden_run_config = make_run_config(\n",
@@ -589,7 +678,7 @@
     "golden_result = run_baseline_eval(\n",
     "    split_rows=golden_rows,\n",
     "    config=golden_run_config,\n",
-    "    predictor=stub_predictor,\n",
+    "    predictor=real_predictor,\n",
     "    output_dir=GOLDEN_OUTPUT_DIR,\n",
     ")\n",
     "\n",
@@ -611,14 +700,16 @@
    "id": "roundtrip-doc",
    "metadata": {},
    "source": [
-    "## 8. Artifact Round-Trip Validation\n\nVerify that the artifacts written to disk reload correctly on a fresh kernel and that `summary.json` can be re-derived from `eval_records.jsonl` alone. This confirms the pipeline is stable across restarts."
+    "## 8. Artifact Round-Trip Validation\n",
+    "\n",
+    "Verify that the artifacts written to disk reload correctly on a fresh kernel and that `summary.json` can be re-derived from `eval_records.jsonl` alone. This confirms the pipeline is stable across restarts."
    ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "roundtrip-verify",
    "metadata": {},
-   "execution_count": null,
    "outputs": [],
    "source": [
     "reloaded_records = read_eval_records_jsonl(OUTPUT_DIR / \"eval_records.jsonl\")\n",
@@ -655,7 +746,18 @@
    "id": "method",
    "metadata": {},
    "source": [
-    "## Method and Outputs\n\n### Method\n1. **Ingest:** Load `SplitArtifactRow` records from `data/eval/val.jsonl` (or synthetic fallback).\n2. **Predict:** Apply the predictor (stub here; real model once inference is wired up).\n3. **Normalize:** Apply the versioned normalizer specified by `NORMALIZER_ID`.\n4. **Score:** Exact-match `normalized_prediction` against `gold`.\n5. **Report:** Write four artifacts; display overall + per-category accuracy; flag failure cases and normalizer drift.\n\n### Expected Outputs\n- `data/eval/runs/baseline-stub-v1/predictions.jsonl` - raw predictions before normalization\n- `data/eval/runs/baseline-stub-v1/eval_records.jsonl` - scored EvalRecord rows\n- `data/eval/runs/baseline-stub-v1/run_config.json` - run configuration snapshot\n- `data/eval/runs/baseline-stub-v1/summary.json` - aggregate metrics\n- `data/eval/runs/baseline-stub-v1-golden/` - same four artifacts for the golden split"
+    "## Method and Outputs\n",
+    "\n",
+    "### Method\n",
+    "1. **Ingest:** Load `SplitArtifactRow` records from `data/eval/val.jsonl` (or synthetic fallback).\n",
+    "2. **Predict:** Apply the real model predictor via `model.generate()` with parameters from `DECODE_CONFIG`.\n",
+    "3. **Normalize:** Apply the versioned normalizer specified by `NORMALIZER_ID`.\n",
+    "4. **Score:** Exact-match `normalized_prediction` against `gold`.\n",
+    "5. **Report:** Write four artifacts; display overall + per-category accuracy; flag failure cases and normalizer drift.\n",
+    "\n",
+    "### Outputs (baseline-real-v1)\n",
+    "- `docs/eval/baseline_summary.json` - committed; aggregate metrics for this run\n",
+    "- `baseline_results.jsonl` - (200 raw predictions, lives in `/kaggle/working/`)"
    ]
   },
   {
@@ -663,7 +765,16 @@
    "id": "assumptions",
    "metadata": {},
    "source": [
-    "## Provisional Assumptions\n\n| # | Assumption | Risk if wrong | Mitigation |\n|---|---|---|---|\n| A1 | Competition evaluator uses exact-match (possibly with strip) | Local accuracy over-counts real score | Run dual-normalizer eval (`exact_v1` + `strip_v1`); report both |\n| A2 | `strip_v1` is the right baseline normalizer | If Kaggle is char-exact, we over-relax | Confirm against official evaluation metric; switch to `exact_v1` if needed |\n| A3 | Val + golden splits are synthetic (no real data yet) | Synthetic distribution != real distribution | Replace with real JSONL from #17/#18 when available |\n| A4 | Stub predictor accuracy (~68%) does not represent real baseline | - | Replace stub with real model; pipeline unchanged |\n| A5 | Decode: greedy, `enable_thinking=False` | Thinking ON may change answer format/accuracy | Issue #21 sweeps this; each config gets its own `run_id` |\n| A6 | Token counts use `len(prompt)//4` proxy | Inaccurate cost/latency reporting | Replace with `tokenizer.encode()` counts in real runs |"
+    "## Provisional Assumptions\n",
+    "\n",
+    "| # | Assumption | Status | Risk if wrong | Mitigation |\n",
+    "|---|---|---|---|---|\n",
+    "| A1 | Competition evaluator uses exact-match (possibly with strip) | Unconfirmed | Local accuracy over-counts real score | Run dual-normalizer eval (`exact_v1` + `strip_v1`); report both |\n",
+    "| A2 | `strip_v1` is the right baseline normalizer | **Invalidated** — model output is a reasoning trace, not a plain answer | Normalizer can never match gold on truncated output | Blocked on `#21` output parser resolution |\n",
+    "| A3 | Val + golden splits are real Kaggle data | Confirmed — 200 real examples used in `baseline-real-v1` | — | — |\n",
+    "| A4 | Stub predictor accuracy (~68%) does not represent real baseline | **Confirmed** — real baseline is 0% | — | Real baseline run complete; root cause identified |\n",
+    "| A5 | Decode: greedy, `enable_thinking=False` | Confirmed for this run — model still produces long reasoning traces regardless | Reasoning trace fills context before final answer is written | `max_new_tokens` must increase to 2048–4096; issue `#21` sweeps this |\n",
+    "| A6 | Token counts use `len(prompt)//4` proxy | **Fixed** — real run uses `tokenizer.encode()` counts | — | — |"
    ]
   },
   {
@@ -671,7 +782,15 @@
    "id": "risks",
    "metadata": {},
    "source": [
-    "## Results / Open Risks\n\n**Current state:** The pipeline is validated end-to-end with a deterministic stub predictor. All four artifact types write, reload correctly, and produce consistent summaries. The golden gate passes with all synthetic golden examples.\n\n**Open risks:**\n- If the competition adds category-specific normalization (e.g., case folding for `numeral_system`), `strip_v1` will undercount accuracy. Mitigation: a dedicated `lower_v1` normalizer with dual-normalizer eval.\n- The golden set (7 synthetic examples) is too small for statistical significance; it guards regressions only. Real golden examples from `#18` should replace these.\n- `latency_ms` from the stub is not representative. Profiling under the real model may reveal categories with very long reasoning traces.\n- The stub wrong-answer generators simulate failure modes but may not match real model failures. Failure analysis will be more informative once real inference runs."
+    "## Results / Open Risks\n",
+    "\n",
+    "**Current state:** The pipeline is validated end-to-end with the real Nemotron-3-Nano-30B model. All four artifact types write and reload correctly. Baseline run `baseline-real-v1` completed 200 examples with **0% accuracy** — root cause identified as `max_new_tokens=512` truncating the model's reasoning trace before it reaches a final answer.\n",
+    "\n",
+    "**Open risks:**\n",
+    "- `max_new_tokens=512` must be increased to 2048–4096 before any meaningful accuracy signal is possible. Handed off to `#21`.\n",
+    "- The output parser contract is unresolved. Even when the model completes reasoning (one case observed), `strip_v1` cannot extract the answer from surrounding markdown or prose. `#21` must resolve this before sweep results can be trusted.\n",
+    "- The golden gate will fail under the real model until the token limit and parser issues are resolved. This is expected and does not indicate a pipeline bug.\n",
+    "- Category-specific normalization (e.g., case folding for `numeral_system`) may be needed — deferred to `#21`."
    ]
   },
   {
@@ -679,8 +798,39 @@
    "id": "sources",
    "metadata": {},
    "source": [
-    "## Sources\n\n- [`docs/architecture/ARCHITECTURE.md`](../docs/architecture/ARCHITECTURE.md) - EvalRecord contract and evaluation layer design\n- [`docs/architecture/COMPETITION.md`](../docs/architecture/COMPETITION.md) - answer format and scoring assumptions\n- [`docs/analysis/ADVERSARIAL_REVIEW.md`](../docs/analysis/ADVERSARIAL_REVIEW.md) - exact-match rationale vs. LaTeX formatting\n- [`docs/planning/plan_v0.2.md`](../docs/planning/plan_v0.2.md) - evaluation protocol and determinism requirements\n- [`docs/execution/plans/issue-19-baseline-eval-and-normalization.md`](../docs/execution/plans/issue-19-baseline-eval-and-normalization.md) - task breakdown\n- [`src/evaluation/normalization.py`](../src/evaluation/normalization.py) - versioned normalizer registry\n- [`src/evaluation/runner.py`](../src/evaluation/runner.py) - pipeline implementation\n- [`src/evaluation/golden_gate.py`](../src/evaluation/golden_gate.py) - regression gate implementation\n- [`src/contracts.py`](../src/contracts.py) - canonical data contracts (EvalRecord, ReasoningExample)"
+    "## Sources\n",
+    "\n",
+    "- [`docs/architecture/ARCHITECTURE.md`](../docs/architecture/ARCHITECTURE.md) - EvalRecord contract and evaluation layer design\n",
+    "- [`docs/architecture/COMPETITION.md`](../docs/architecture/COMPETITION.md) - answer format and scoring assumptions\n",
+    "- [`docs/analysis/ADVERSARIAL_REVIEW.md`](../docs/analysis/ADVERSARIAL_REVIEW.md) - exact-match rationale vs. LaTeX formatting\n",
+    "- [`docs/planning/plan_v0.2.md`](../docs/planning/plan_v0.2.md) - evaluation protocol and determinism requirements\n",
+    "- [`docs/execution/plans/issue-19-baseline-eval-and-normalization.md`](../docs/execution/plans/issue-19-baseline-eval-and-normalization.md) - task breakdown\n",
+    "- [`src/evaluation/normalization.py`](../src/evaluation/normalization.py) - versioned normalizer registry\n",
+    "- [`src/evaluation/runner.py`](../src/evaluation/runner.py) - pipeline implementation\n",
+    "- [`src/evaluation/golden_gate.py`](../src/evaluation/golden_gate.py) - regression gate implementation\n",
+    "- [`src/contracts.py`](../src/contracts.py) - canonical data contracts (EvalRecord, ReasoningExample)"
    ]
   }
- ]
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
 }


### PR DESCRIPTION
Replaces the stub predictor in notebook 04 with the real Nemotron-3-Nano-30B model and documents the first real baseline eval run against 200 Kaggle competition examples. Closes out the code side of #19 and hands two concrete open problems to #21.

**What changed:**
Notebook 04 — stub predictor replaced with real model load and inference; run config, assumptions table, and all stale text cells updated to reflect actual results. Also committing docs/eval/baseline-real-v1-summary.json as the summary artifact for the run.

**Baseline results:**
200 rows, all 6 categories, seed=42, accuracy 0.0%.
The 0% is not a pipeline bug. It has two confirmed causes: max_new_tokens=512 truncates the model's reasoning trace before it reaches a final answer on nearly every example, and the output parser can't extract a final answer from a truncated or prose-wrapped reasoning trace. One example (5a6ed2bf, numeral_system) completed reasoning successfully but the parser still failed due to markdown formatting around the answer.

**Handoff to #21:**
max_new_tokens needs to increase to 2048–4096, and the output parser contract needs to be resolved before sweep results can be trusted. This run confirms the PENDING_REVIEW.md output parser discrepancy with real inference data.

baseline_results.jsonl (200 raw predictions) is not committed per the data/** git-ignore policy — it lives in /kaggle/working/ from the original run.